### PR TITLE
misc updates

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonConnection.java
+++ b/src/main/java/io/vertx/proton/ProtonConnection.java
@@ -3,7 +3,6 @@ package io.vertx.proton;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.apache.qpid.proton.message.Message;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -45,7 +44,7 @@ public interface ProtonConnection {
   /**
    * Creates a sender used to send messages to the given node address. If no address
    * (i.e null) is specified then a sender will be established to the 'anonymous relay'
-   * and each message must specify its destination in its 'to' field.
+   * and each message must specify its destination address.
    *
    * @param address The target address to attach to, or null to attach to the anonymous relay.
    *

--- a/src/main/java/io/vertx/proton/ProtonConnection.java
+++ b/src/main/java/io/vertx/proton/ProtonConnection.java
@@ -33,16 +33,21 @@ public interface ProtonConnection {
 
   ProtonConnection close();
 
-  ProtonReceiver receiver(String name);
-
-  ProtonReceiver receiver();
+  /**
+   * Creates a receiver used to consumer messages from the given node address.
+   *
+   * @param address The source address to attach the consumer to.
+   *
+   * @return the (unopened) consumer.
+   */
+  ProtonReceiver createReceiver(String address);
 
   /**
    * Creates a sender used to send messages to the given node address. If no address
    * (i.e null) is specified then a sender will be established to the 'anonymous relay'
    * and each message must specify its destination in its 'to' field.
    *
-   * @param address The address to attach to, or null to attach to the anonymous relay.
+   * @param address The target address to attach to, or null to attach to the anonymous relay.
    *
    * @return the (unopened) sender.
    */

--- a/src/main/java/io/vertx/proton/ProtonConnection.java
+++ b/src/main/java/io/vertx/proton/ProtonConnection.java
@@ -33,15 +33,29 @@ public interface ProtonConnection {
 
   ProtonConnection close();
 
-  ProtonSession session();
-
-  void send(byte[] tag, Message message);
-
-  void send(byte[] tag, Message message, Handler<ProtonDelivery> onReceived);
-
   ProtonReceiver receiver(String name);
 
   ProtonReceiver receiver();
+
+  /**
+   * Creates a sender used to send messages to the given node address. If no address
+   * (i.e null) is specified then a sender will be established to the 'anonymous relay'
+   * and each message must specify its destination in its 'to' field.
+   *
+   * @param address The address to attach to, or null to attach to the anonymous relay.
+   *
+   * @return the (unopened) sender.
+   */
+  ProtonSender createSender(String address);
+
+  /**
+   * Allows querying (once the connection has remotely opened) whether the peer
+   * advertises support for the anonymous relay (sender with null address).
+   * @return
+   */
+  boolean isAnonymousRelaySupported();
+
+  ProtonSession session();
 
   void disconnect();
 
@@ -59,5 +73,4 @@ public interface ProtonConnection {
 
   ProtonConnection receiverOpenHandler(Handler<ProtonReceiver> remoteReceiverOpenHandler);
 
-  boolean isAnonymousRelaySupported();
 }

--- a/src/main/java/io/vertx/proton/ProtonConnection.java
+++ b/src/main/java/io/vertx/proton/ProtonConnection.java
@@ -59,7 +59,12 @@ public interface ProtonConnection {
    */
   boolean isAnonymousRelaySupported();
 
-  ProtonSession session();
+  /**
+   * Creates a new session, which can be used to create new senders/receivers on.
+   *
+   * @return the (unopened) session.
+   */
+  ProtonSession createSession();
 
   void disconnect();
 

--- a/src/main/java/io/vertx/proton/ProtonSession.java
+++ b/src/main/java/io/vertx/proton/ProtonSession.java
@@ -27,9 +27,7 @@ public interface ProtonSession {
 
   ProtonSession closeHandler(Handler<AsyncResult<ProtonSession>> closeHandler);
 
-  ProtonSender sender();
-
-  ProtonSender sender(String name);
+  ProtonSender createSender(String address);
 
   ProtonReceiver createReceiver(String address);
 }

--- a/src/main/java/io/vertx/proton/ProtonSession.java
+++ b/src/main/java/io/vertx/proton/ProtonSession.java
@@ -31,8 +31,5 @@ public interface ProtonSession {
 
   ProtonSender sender(String name);
 
-  ProtonReceiver receiver();
-
-  ProtonReceiver receiver(String name);
-
+  ProtonReceiver createReceiver(String address);
 }

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -203,22 +203,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
 
     @Override
     public ProtonSender createSender(String address) {
-        //TODO: move most of this into the session for reuse.
-
-        //TODO: add a default close/error handler?
-        ProtonSender sender = getDefaultSession().sender();
-
-        Symbol[] outcomes = new Symbol[]{ Accepted.DESCRIPTOR_SYMBOL, Rejected.DESCRIPTOR_SYMBOL, Released.DESCRIPTOR_SYMBOL, Modified.DESCRIPTOR_SYMBOL};
-        Source source = new Source();
-        source.setOutcomes(outcomes);
-
-        Target target = new Target();
-        target.setAddress(address);
-
-        sender.setSource(source);
-        sender.setTarget(target);
-
-        return sender;
+        return getDefaultSession().createSender(address);
     }
 
     @Override

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -12,12 +12,6 @@ import java.util.UUID;
 
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
-import org.apache.qpid.proton.amqp.messaging.Accepted;
-import org.apache.qpid.proton.amqp.messaging.Modified;
-import org.apache.qpid.proton.amqp.messaging.Rejected;
-import org.apache.qpid.proton.amqp.messaging.Released;
-import org.apache.qpid.proton.amqp.messaging.Source;
-import org.apache.qpid.proton.amqp.messaging.Target;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.Connection;
 import org.apache.qpid.proton.engine.EndpointState;
@@ -62,8 +56,6 @@ public class ProtonConnectionImpl implements ProtonConnection {
     };
     private boolean anonymousRelaySupported;
     private ProtonSession defaultSession;
-    private ProtonSender defaultSender;
-
 
     ProtonConnectionImpl(Vertx vertx, String hostname) {
         this.vertx = vertx;

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -180,7 +180,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
     }
 
     @Override
-    public ProtonSessionImpl session() {
+    public ProtonSessionImpl createSession() {
         return new ProtonSessionImpl(connection.session());
     }
 

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -222,13 +222,8 @@ public class ProtonConnectionImpl implements ProtonConnection {
     }
 
     @Override
-    public ProtonReceiver receiver(String name) {
-        return getDefaultSession().receiver(name);
-    }
-
-    @Override
-    public ProtonReceiver receiver() {
-        return getDefaultSession().receiver();
+    public ProtonReceiver createReceiver(String address) {
+        return getDefaultSession().createReceiver(address);
     }
 
     public void flush() {

--- a/src/main/java/io/vertx/proton/impl/ProtonSenderImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSenderImpl.java
@@ -18,16 +18,22 @@ import org.apache.qpid.proton.message.impl.MessageImpl;
 public class ProtonSenderImpl extends ProtonLinkImpl<ProtonSender> implements ProtonSender {
 
     private Handler<ProtonSender> drainHandler;
+    private boolean anonymousSender;
 
     ProtonSenderImpl(Sender sender) {
         super(sender);
     }
+
     private Sender sender() {
         return (Sender)link;
     }
 
     @Override
     public void send(byte[] tag, Message message, Handler<ProtonDelivery> onReceived) {
+        if(anonymousSender && message.getAddress() == null) {
+            throw new IllegalArgumentException("Message must have an address when using anonymous sender.");
+        }
+        // TODO: prevent odd combination of onRecieved callback + SenderSettleMode.SETTLED, or just allow it?
 
         Delivery delivery = sender().delivery(tag); // start a new delivery..
         int BUFFER_SIZE = 1024;
@@ -57,6 +63,14 @@ public class ProtonSenderImpl extends ProtonLinkImpl<ProtonSender> implements Pr
 
     public void send(byte[] tag, Message message) {
         send(tag, message, null);
+    }
+
+    public boolean isAnonymousSender() {
+        return anonymousSender;
+    }
+
+    public void setAnonymousSender(boolean anonymousSender) {
+        this.anonymousSender = anonymousSender;
     }
 
     @Override

--- a/src/main/java/io/vertx/proton/impl/ProtonSenderImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSenderImpl.java
@@ -52,6 +52,7 @@ public class ProtonSenderImpl extends ProtonLinkImpl<ProtonSender> implements Pr
         }
         sender().send(encodedMessage, 0, len);
 
+        //TODO: even if onRecieved is null, we shouldnt really settle if the link was established was SenderSettleMode.UNSETTLED
         if( onReceived==null || link.getSenderSettleMode() == SenderSettleMode.SETTLED  ) {
             delivery.settle();
         }

--- a/src/main/java/io/vertx/proton/impl/ProtonSessionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSessionImpl.java
@@ -163,6 +163,10 @@ public class ProtonSessionImpl implements ProtonSession {
         sender.setTarget(target);
 
         ProtonSenderImpl s = new ProtonSenderImpl(sender);
+        if(address == null) {
+            s.setAnonymousSender(true);
+        }
+
         //TODO: set explicit defaults for settle mode etc?
         return s;
     }

--- a/src/main/java/io/vertx/proton/impl/ProtonSessionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSessionImpl.java
@@ -119,29 +119,15 @@ public class ProtonSessionImpl implements ProtonSession {
         return this;
     }
 
-    @Override
-    public ProtonSender sender() {
-        return sender(generateLinkName());
-    }
-
     private String generateLinkName() {
         //TODO: include useful details in name, like address and container?
         return "auto-"+(autoLinkCounter++);
     }
 
     @Override
-    public ProtonSender sender(String name) {
-        Sender sender = session.sender(name);
-        if (sender.getContext() != null) {
-            return (ProtonSender) sender.getContext();
-        } else {
-            return new ProtonSenderImpl(sender);
-        }
-    }
-
-    @Override
     public ProtonReceiver createReceiver(String address) {
         //TODO: add options for configuring things like link name etc?
+        //TODO: add a default close/error handler?
         Receiver receiver = session.receiver(generateLinkName());
 
         Symbol[] outcomes = new Symbol[]{ Accepted.DESCRIPTOR_SYMBOL, Rejected.DESCRIPTOR_SYMBOL, Released.DESCRIPTOR_SYMBOL, Modified.DESCRIPTOR_SYMBOL};
@@ -159,6 +145,26 @@ public class ProtonSessionImpl implements ProtonSession {
         ProtonReceiverImpl r = new ProtonReceiverImpl(receiver);
         //TODO: set explicit defaults for settle mode etc?
         return r;
+    }
+
+    @Override
+    public ProtonSender createSender(String address) {
+        //TODO: add a default close/error handler?
+        Sender sender = session.sender(generateLinkName());
+
+        Symbol[] outcomes = new Symbol[]{ Accepted.DESCRIPTOR_SYMBOL, Rejected.DESCRIPTOR_SYMBOL, Released.DESCRIPTOR_SYMBOL, Modified.DESCRIPTOR_SYMBOL};
+        Source source = new Source();
+        source.setOutcomes(outcomes);
+
+        Target target = new Target();
+        target.setAddress(address);
+
+        sender.setSource(source);
+        sender.setTarget(target);
+
+        ProtonSenderImpl s = new ProtonSenderImpl(sender);
+        //TODO: set explicit defaults for settle mode etc?
+        return s;
     }
 
     /////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -91,7 +91,7 @@ class ProtonTransport extends BaseHandler {
                     break;
                 }
                 case LINK_REMOTE_OPEN: {
-                    ProtonLinkImpl link = (ProtonLinkImpl) protonEvent.getLink().getContext();
+                    ProtonLinkImpl<?> link = (ProtonLinkImpl<?>) protonEvent.getLink().getContext();
                     if( link == null ) {
                         connnection.fireRemoteLinkOpen(protonEvent.getLink());
                     } else {
@@ -100,12 +100,12 @@ class ProtonTransport extends BaseHandler {
                     break;
                 }
                 case LINK_REMOTE_CLOSE: {
-                    ProtonLinkImpl link = (ProtonLinkImpl) protonEvent.getLink().getContext();
+                    ProtonLinkImpl<?> link = (ProtonLinkImpl<?>) protonEvent.getLink().getContext();
                     link.fireRemoteClose();
                     break;
                 }
                 case LINK_FLOW:{
-                    ProtonLinkImpl link = (ProtonLinkImpl) protonEvent.getLink().getContext();
+                    ProtonLinkImpl<?> link = (ProtonLinkImpl<?>) protonEvent.getLink().getContext();
                     link.fireLinkFlow();
                     break;
                 }

--- a/src/test/java/io/vertx/proton/MockServer.java
+++ b/src/test/java/io/vertx/proton/MockServer.java
@@ -22,6 +22,7 @@ public class MockServer {
 
     private ProtonServer server;
     private ProtonSender echoSender;
+    private volatile int credits = 1000;
 
     enum Addresses {
         command,
@@ -56,7 +57,7 @@ public class MockServer {
                     address = receiver.getRemoteTarget().getAddress();
                 }
                 processMessage(connection, receiver, delivery, msg, address);
-            }).flow(100000).open();
+            }).flow(credits).open();
         });
         connection.senderOpenHandler(sender->{
             Addresses address = null;
@@ -109,6 +110,13 @@ public class MockServer {
 
     }
 
+    public int getProducerCredits() {
+        return credits;
+    }
+
+    public void setProducerCredits(int credits) {
+        this.credits = credits;
+    }
 
     public void close() {
         server.close();

--- a/src/test/java/io/vertx/proton/MockServer.java
+++ b/src/test/java/io/vertx/proton/MockServer.java
@@ -93,6 +93,9 @@ public class MockServer {
                         }
                         break;
                     }
+                    case drop:{
+                        sender.open();
+                    }
                     default:
                         sender.setCondition(condition("Unknown address")).close();
                 }

--- a/src/test/java/io/vertx/proton/MockServerTestBase.java
+++ b/src/test/java/io/vertx/proton/MockServerTestBase.java
@@ -23,7 +23,6 @@ import io.vertx.ext.unit.TestContext;
 import org.junit.After;
 import org.junit.Before;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 abstract public class MockServerTestBase {

--- a/src/test/java/io/vertx/proton/ProtonBenchmark.java
+++ b/src/test/java/io/vertx/proton/ProtonBenchmark.java
@@ -35,7 +35,7 @@ public class ProtonBenchmark extends MockServerTestBase {
         connect(context, connection ->
         {
             ProtonSender sender =
-                connection.session().open().sender()
+                connection.session().open().createSender(MockServer.Addresses.drop.toString())
                     .setQoS(ProtonQoS.AT_LEAST_ONCE)
                     .open();
 
@@ -64,7 +64,7 @@ public class ProtonBenchmark extends MockServerTestBase {
         connect(context, connection ->
         {
             ProtonSender sender =
-                connection.session().open().sender()
+                connection.session().open().createSender(MockServer.Addresses.drop.toString())
                     .setQoS(ProtonQoS.AT_MOST_ONCE)
                     .open();
 
@@ -92,7 +92,7 @@ public class ProtonBenchmark extends MockServerTestBase {
         connect(context, connection ->
         {
             ProtonSession session = connection.session().open();
-            ProtonSender sender = session.sender().open();
+            ProtonSender sender = session.createSender(MockServer.Addresses.echo.toString()).open();
 
             byte[] tag = tag("m1");
             Message message = message("echo", "Hello World");

--- a/src/test/java/io/vertx/proton/ProtonBenchmark.java
+++ b/src/test/java/io/vertx/proton/ProtonBenchmark.java
@@ -31,11 +31,13 @@ public class ProtonBenchmark extends MockServerTestBase {
 
     @Test
     public void benchmarkAtLeastOnceSendThroughput(TestContext context) {
+        server.setProducerCredits(1000);
+
         Async async = context.async();
         connect(context, connection ->
         {
             ProtonSender sender =
-                connection.session().open().createSender(MockServer.Addresses.drop.toString())
+                connection.createSender(MockServer.Addresses.drop.toString())
                     .setQoS(ProtonQoS.AT_LEAST_ONCE)
                     .open();
 
@@ -60,11 +62,13 @@ public class ProtonBenchmark extends MockServerTestBase {
 
     @Test
     public void benchmarkAtMostOnceSendThroughput(TestContext context) {
+        server.setProducerCredits(100000);
+
         Async async = context.async();
         connect(context, connection ->
         {
             ProtonSender sender =
-                connection.session().open().createSender(MockServer.Addresses.drop.toString())
+                connection.createSender(MockServer.Addresses.drop.toString())
                     .setQoS(ProtonQoS.AT_MOST_ONCE)
                     .open();
 
@@ -88,22 +92,24 @@ public class ProtonBenchmark extends MockServerTestBase {
 
     @Test
     public void benchmarkRequestResponse(TestContext context) {
+        int credits = 10;
+        server.setProducerCredits(credits);
+
         Async async = context.async();
         connect(context, connection ->
         {
-            ProtonSession session = connection.session().open();
-            ProtonSender sender = session.createSender(MockServer.Addresses.echo.toString()).open();
+            ProtonSender sender = connection.createSender(MockServer.Addresses.echo.toString()).open();
 
             byte[] tag = tag("m1");
             Message message = message("echo", "Hello World");
 
             benchmark(BENCHMARK_DURATION, "Request Response Throughput", counter -> {
 
-                session.createReceiver(MockServer.Addresses.echo.toString())
+                connection.createReceiver(MockServer.Addresses.echo.toString())
                     .handler((d, m)->{
                         counter.incrementAndGet();
                     })
-                    .flow(10)
+                    .flow(credits)
                     .open();
 
                 sender.sendQueueDrainHandler(s -> {

--- a/src/test/java/io/vertx/proton/ProtonBenchmark.java
+++ b/src/test/java/io/vertx/proton/ProtonBenchmark.java
@@ -99,7 +99,7 @@ public class ProtonBenchmark extends MockServerTestBase {
 
             benchmark(BENCHMARK_DURATION, "Request Response Throughput", counter -> {
 
-                session.receiver("echo")
+                session.createReceiver(MockServer.Addresses.echo.toString())
                     .handler((d, m)->{
                         counter.incrementAndGet();
                     })

--- a/src/test/java/io/vertx/proton/ProtonClientTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientTest.java
@@ -93,9 +93,7 @@ public class ProtonClientTest extends MockServerTestBase {
     private void sendReceiveEcho(TestContext context, String data) {
         Async async = context.async();
         connect(context, connection -> {
-
-            ProtonSession session = connection.session().open();
-            session.createReceiver(MockServer.Addresses.echo.toString())
+            connection.createReceiver(MockServer.Addresses.echo.toString())
                 .handler((d, m) -> {
                     String actual = (String) (getMessageBody(context, m));
                     context.assertEquals(data, actual);
@@ -105,7 +103,7 @@ public class ProtonClientTest extends MockServerTestBase {
                 .flow(10)
                 .open();
 
-            session.createSender(MockServer.Addresses.echo.toString())
+            connection.createSender(MockServer.Addresses.echo.toString())
                 .open()
                 .send(tag(""), message("echo", data));
 
@@ -119,8 +117,7 @@ public class ProtonClientTest extends MockServerTestBase {
         connect(context, connection -> {
 
             AtomicInteger counter = new AtomicInteger(0);
-            ProtonSession session = connection.session().open();
-            session.createReceiver(MockServer.Addresses.two_messages.toString())
+            connection.createReceiver(MockServer.Addresses.two_messages.toString())
                 .asyncHandler((d, m, settle) -> {
                     int count = counter.incrementAndGet();
                     switch (count) {
@@ -162,8 +159,7 @@ public class ProtonClientTest extends MockServerTestBase {
         connect(context, connection -> {
 
             AtomicInteger counter = new AtomicInteger(0);
-            ProtonSession session = connection.session().open();
-            session.createReceiver(MockServer.Addresses.five_messages.toString())
+            connection.createReceiver(MockServer.Addresses.five_messages.toString())
                 .asyncHandler((d, m, settle) -> {
                     int count = counter.incrementAndGet();
                     switch (count) {

--- a/src/test/java/io/vertx/proton/ProtonClientTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientTest.java
@@ -94,7 +94,7 @@ public class ProtonClientTest extends MockServerTestBase {
         connect(context, connection -> {
 
             ProtonSession session = connection.session().open();
-            session.receiver("echo")
+            session.createReceiver(MockServer.Addresses.echo.toString())
                 .handler((d, m) -> {
                     String actual = (String) (getMessageBody(context, m));
                     context.assertEquals(data, actual);
@@ -119,7 +119,7 @@ public class ProtonClientTest extends MockServerTestBase {
 
             AtomicInteger counter = new AtomicInteger(0);
             ProtonSession session = connection.session().open();
-            session.receiver().setSource("two_messages")
+            session.createReceiver(MockServer.Addresses.two_messages.toString())
                 .asyncHandler((d, m, settle) -> {
                     int count = counter.incrementAndGet();
                     switch (count) {
@@ -162,7 +162,7 @@ public class ProtonClientTest extends MockServerTestBase {
 
             AtomicInteger counter = new AtomicInteger(0);
             ProtonSession session = connection.session().open();
-            session.receiver().setSource(MockServer.Addresses.five_messages.toString())
+            session.createReceiver(MockServer.Addresses.five_messages.toString())
                 .asyncHandler((d, m, settle) -> {
                     int count = counter.incrementAndGet();
                     switch (count) {

--- a/src/test/java/io/vertx/proton/ProtonClientTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientTest.java
@@ -104,7 +104,7 @@ public class ProtonClientTest extends MockServerTestBase {
                 .flow(10)
                 .open();
 
-            session.sender()
+            session.createSender(MockServer.Addresses.echo.toString())
                 .open()
                 .send(tag(""), message("echo", data));
 

--- a/src/test/java/io/vertx/proton/ProtonClientTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientTest.java
@@ -54,8 +54,10 @@ public class ProtonClientTest extends MockServerTestBase {
                 context.assertTrue(connection.isDisconnected());
                 async.complete();
             });
-            // Send a reqeust to the sever for him to disconnect us
-            connection.send(tag(""), message("command", "disconnect"));
+
+            // Send a request to the server for him to disconnect us
+            ProtonSender sender = connection.createSender(null).open();
+            sender.send(tag(""), message("command", "disconnect"));
         });
     }
 
@@ -259,7 +261,13 @@ public class ProtonClientTest extends MockServerTestBase {
                 ProtonConnection connection =  res.result();
                 connection.openHandler(x -> {
                     LOG.trace("Client connection opened");
-                    connection.send(tag("tag"), message("ignored", "content"));
+
+                    ProtonSender sender = connection.createSender(null);
+                    // Can optionally add an openHandler or sendQueueDrainHandler
+                    // to await remote sender open completing or credit to send being
+                    // granted. But here we will just buffer the send immediately.
+                    sender.open();
+                    sender.send(tag("tag"), message("ignored", "content"));
                 })
                 .open();
             });

--- a/src/test/java/io/vertx/proton/example/HelloWorld.java
+++ b/src/test/java/io/vertx/proton/example/HelloWorld.java
@@ -49,7 +49,9 @@ public class HelloWorld {
         connection.open();
 
         // Receive messages from a queue
-        connection.createReceiver("queue://foo")
+        String address = "queue://foo";
+
+        connection.createReceiver(address)
             .handler((delivery, msg) -> {
                 Section body = msg.getBody();
                 if (body instanceof AmqpValue) {
@@ -60,11 +62,12 @@ public class HelloWorld {
             .flow(10)  // Prefetch up to 10 messages
             .open();
 
-
-        // Send messages to a queue..
-        Message message = message("queue://foo", "Hello World from client");
-
+        // Create an anonymous sender, have the message carry the destination
         ProtonSender sender = connection.createSender(null);
+
+        // Send message to the queue..
+        Message message = message(address, "Hello World from client");
+
         // Can optionally add an openHandler or sendQueueDrainHandler
         // to await remote sender open completing or credit to send being
         // granted. But here we will just buffer the send immediately.

--- a/src/test/java/io/vertx/proton/example/HelloWorld.java
+++ b/src/test/java/io/vertx/proton/example/HelloWorld.java
@@ -49,7 +49,7 @@ public class HelloWorld {
         connection.open();
 
         // Receive messages from a queue
-        connection.receiver().setSource("queue://foo")
+        connection.createReceiver("queue://foo")
             .handler((delivery, msg) -> {
                 Section body = msg.getBody();
                 if (body instanceof AmqpValue) {
@@ -69,8 +69,9 @@ public class HelloWorld {
         // to await remote sender open completing or credit to send being
         // granted. But here we will just buffer the send immediately.
         sender.open();
+        System.out.println("Sending message to server");
         sender.send(tag("m1"), message, delivery -> {
-            System.out.println("The message was sent");
+            System.out.println("The message was received by the server");
         });
     }
 

--- a/src/test/java/io/vertx/proton/example/HelloWorld.java
+++ b/src/test/java/io/vertx/proton/example/HelloWorld.java
@@ -6,6 +6,8 @@ package io.vertx.proton.example;
 import io.vertx.core.Vertx;
 import io.vertx.proton.ProtonClient;
 import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonSender;
+
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Section;
 import org.apache.qpid.proton.message.Message;
@@ -61,10 +63,15 @@ public class HelloWorld {
 
         // Send messages to a queue..
         Message message = message("queue://foo", "Hello World from client");
-        connection.send(tag("m1"), message, delivery -> {
+
+        ProtonSender sender = connection.createSender(null);
+        // Can optionally add an openHandler or sendQueueDrainHandler
+        // to await remote sender open completing or credit to send being
+        // granted. But here we will just buffer the send immediately.
+        sender.open();
+        sender.send(tag("m1"), message, delivery -> {
             System.out.println("The message was sent");
         });
-
     }
 
 }

--- a/src/test/java/io/vertx/proton/example/HelloWorldServer.java
+++ b/src/test/java/io/vertx/proton/example/HelloWorldServer.java
@@ -87,7 +87,7 @@ public class HelloWorldServer {
                     System.out.println("Sending message to client");
                     Message m = message("Hello World from Server!");
                     sender.send(tag("m1"), m, delivery -> {
-                        System.out.println("The message was sent");
+                        System.out.println("The message was received by the client.");
                     });
                 }
             });


### PR DESCRIPTION
- Have sender+reciever creation calls take an address, simplify creation a bit
- Set the source+target fields as appropriate
- Always use a sender for sending messages, either to a fixed address or the anonymous relay, allowing it to be configured as needed and giving us something to use for error handling later
- Some tidyup and various notes for later
- Benchmark tweaks around credit