### PR TITLE
Disabled raising flow event (credits granted by receiver) for each message sent

### DIFF
--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -62,6 +62,7 @@ class ProtonTransport extends BaseHandler {
     this.netClient = netClient;
     this.socket = socket;
     transport.setMaxFrameSize(1024 * 32); // TODO: make configurable
+    transport.setEmitFlowEventOnSend(false); // TODO: make configurable
     if (authenticator != null) {
       authenticator.init(transport);
     }


### PR DESCRIPTION
See issue #19 
For starting we could disable it as default.