### PR TITLE
Hekonsek server auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,20 +80,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.jayway.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>1.7.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>1.7.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>

--- a/src/main/java/io/vertx/proton/ProtonServer.java
+++ b/src/main/java/io/vertx/proton/ProtonServer.java
@@ -18,6 +18,7 @@ package io.vertx.proton;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.proton.impl.ProtonSaslAuthenticator;
 import io.vertx.proton.impl.ProtonServerImpl;
 
 /**
@@ -34,6 +35,19 @@ public interface ProtonServer {
    */
   static ProtonServer create(Vertx vertx) {
     return new ProtonServerImpl(vertx);
+  }
+
+  /**
+   * Create a ProtonServer instance with the given Vertx instance and SASL authenticator.
+   *
+   * @param vertx
+   *          the vertx instance to use
+   * @param authenticator
+   *          server SASL authenticator to use
+   * @return the server instance
+   */
+  static ProtonServer create(Vertx vertx, ProtonSaslAuthenticator authenticator) {
+    return new ProtonServerImpl(vertx, authenticator);
   }
 
   /**

--- a/src/main/java/io/vertx/proton/ProtonServer.java
+++ b/src/main/java/io/vertx/proton/ProtonServer.java
@@ -18,7 +18,7 @@ package io.vertx.proton;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.proton.impl.ProtonSaslAuthenticator;
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import io.vertx.proton.impl.ProtonServerImpl;
 
 /**

--- a/src/main/java/io/vertx/proton/ProtonServer.java
+++ b/src/main/java/io/vertx/proton/ProtonServer.java
@@ -38,19 +38,6 @@ public interface ProtonServer {
   }
 
   /**
-   * Create a ProtonServer instance with the given Vertx instance and SASL authenticator.
-   *
-   * @param vertx
-   *          the vertx instance to use
-   * @param authenticator
-   *          server SASL authenticator to use
-   * @return the server instance
-   */
-  static ProtonServer create(Vertx vertx, ProtonSaslAuthenticator authenticator) {
-    return new ProtonServerImpl(vertx, authenticator);
-  }
-
-  /**
    * Create a ProtonServer instance with the given Vertx instance and options.
    *
    * @param vertx
@@ -78,6 +65,14 @@ public interface ProtonServer {
    * @return the handler
    */
   Handler<ProtonConnection> connectHandler();
+
+  /**
+   * Sets authenticator to be used by Proton server.
+   *
+   * @param authenticator to be used for connection authentication.
+   * @return configured server
+     */
+  ProtonServer saslAuthenticator(ProtonSaslAuthenticator authenticator);
 
   /**
    * Gets the actual port being listened on.

--- a/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
@@ -63,7 +63,7 @@ public class ProtonClientImpl implements ProtonClient {
         ProtonConnectionImpl amqpConnnection = new ProtonConnectionImpl(vertx, host);
 
         ProtonSaslClientAuthenticatorImpl authenticator = new ProtonSaslClientAuthenticatorImpl(username, password,
-            options.getEnabledSaslMechanisms(), res.result(), connectHandler, amqpConnnection);
+            options.getEnabledSaslMechanisms(), res.result(), connectHandler);
         amqpConnnection.bindClient(netClient, res.result(), authenticator);
 
         // Need to flush here to get the SASL process going, or it will wait until calls on the connection are processed

--- a/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
@@ -63,7 +63,7 @@ public class ProtonClientImpl implements ProtonClient {
         ProtonConnectionImpl amqpConnnection = new ProtonConnectionImpl(vertx, host);
 
         ProtonSaslClientAuthenticatorImpl authenticator = new ProtonSaslClientAuthenticatorImpl(username, password,
-            options.getEnabledSaslMechanisms(), res.result(), connectHandler);
+                options.getEnabledSaslMechanisms(), connectHandler);
         amqpConnnection.bindClient(netClient, res.result(), authenticator);
 
         // Need to flush here to get the SASL process going, or it will wait until calls on the connection are processed

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -357,7 +357,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
     transport = new ProtonTransport(connection, vertx, client, socket, authenticator);
   }
 
-  void bindServer(NetSocket socket, ProtonSaslServerAuthenticatorImpl authenticator) {
+  void bindServer(NetSocket socket, ProtonSaslAuthenticator authenticator) {
     transport = new ProtonTransport(connection, vertx, null, socket, authenticator);
   }
 

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -43,7 +43,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
   private Set<String> mechanismsRestriction;
   private Handler<AsyncResult<ProtonConnection>> handler;
   private NetSocket socket;
-  private ProtonConnectionImpl connection;
+  private ProtonConnection connection;
   private boolean succeeded;
 
   /**
@@ -60,21 +60,19 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
    *          The socket associated with the connection this SASL process is for
    * @param handler
    *          The handler to convey the result of the SASL process to
-   * @param connection
-   *          The connection the SASL process is for
    */
   public ProtonSaslClientAuthenticatorImpl(String username, String password, Set<String> allowedSaslMechanisms,
-      NetSocket socket, Handler<AsyncResult<ProtonConnection>> handler, ProtonConnectionImpl connection) {
+      NetSocket socket, Handler<AsyncResult<ProtonConnection>> handler) {
     this.handler = handler;
     this.socket = socket;
-    this.connection = connection;
     this.username = username;
     this.password = password;
     this.mechanismsRestriction = allowedSaslMechanisms;
   }
 
   @Override
-  public void init(Transport transport) {
+  public void init(ProtonConnection protonConnection, Transport transport) {
+    this.connection = protonConnection;
     this.sasl = transport.sasl();
     sasl.client();
   }
@@ -147,8 +145,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
         }
       }
     } catch (SaslException se) {
-      SecurityException sece = new SecurityException("Exception while processing SASL init.", se);
-      throw sece;
+      throw new SecurityException("Exception while processing SASL init.", se);
     }
   }
 
@@ -161,8 +158,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
         sasl.send(response, 0, response.length);
       }
     } catch (SaslException se) {
-      SecurityException sece = new SecurityException("Exception while processing SASL step.", se);
-      throw sece;
+      throw new SecurityException("Exception while processing SASL step.", se);
     }
   }
 }

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -56,22 +56,19 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
    * @param allowedSaslMechanisms
    *          The possible mechanism(s) to which the client should restrict its mechanism selection to if offered by the
    *          server, or null/empty if no restriction.
-   * @param socket
-   *          The socket associated with the connection this SASL process is for
    * @param handler
    *          The handler to convey the result of the SASL process to
    */
-  public ProtonSaslClientAuthenticatorImpl(String username, String password, Set<String> allowedSaslMechanisms,
-      NetSocket socket, Handler<AsyncResult<ProtonConnection>> handler) {
+  public ProtonSaslClientAuthenticatorImpl(String username, String password, Set<String> allowedSaslMechanisms, Handler<AsyncResult<ProtonConnection>> handler) {
     this.handler = handler;
-    this.socket = socket;
     this.username = username;
     this.password = password;
     this.mechanismsRestriction = allowedSaslMechanisms;
   }
 
   @Override
-  public void init(ProtonConnection protonConnection, Transport transport) {
+  public void init(NetSocket socket, ProtonConnection protonConnection, Transport transport) {
+    this.socket = socket;
     this.connection = protonConnection;
     this.sasl = transport.sasl();
     sasl.client();

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import javax.security.sasl.SaslException;
 
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Transport;
 

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -44,6 +44,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
   private Handler<AsyncResult<ProtonConnection>> handler;
   private NetSocket socket;
   private ProtonConnectionImpl connection;
+  private boolean succeeded;
 
   /**
    * Create the authenticator and initialize it.
@@ -85,6 +86,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
     }
 
     boolean done = false;
+    succeeded = false;
 
     try {
       switch (sasl.getState()) {
@@ -100,6 +102,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
         break;
       case PN_SASL_PASS:
         done = true;
+        succeeded = true;
         handler.handle(Future.succeededFuture(connection));
         break;
       default:
@@ -116,6 +119,11 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
     }
 
     return done;
+  }
+
+  @Override
+  public boolean succeeded() {
+    return succeeded;
   }
 
   private void handleSaslInit() throws SecurityException {

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
@@ -15,6 +15,7 @@
 */
 package io.vertx.proton.impl;
 
+import io.vertx.core.net.NetSocket;
 import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Sasl;
@@ -32,7 +33,7 @@ public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticato
   private boolean succeeded;
 
   @Override
-  public void init(ProtonConnection protonConnection, Transport transport) {
+  public void init(NetSocket socket, ProtonConnection protonConnection, Transport transport) {
     this.sasl = transport.sasl();
     sasl.server();
     sasl.allowSkip(false);

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
@@ -15,6 +15,7 @@
 */
 package io.vertx.proton.impl;
 
+import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Sasl.SaslOutcome;
@@ -31,7 +32,7 @@ public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticato
   private boolean succeeded;
 
   @Override
-  public void init(Transport transport) {
+  public void init(ProtonConnection protonConnection, Transport transport) {
     this.sasl = transport.sasl();
     sasl.server();
     sasl.allowSkip(false);

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
@@ -15,6 +15,7 @@
 */
 package io.vertx.proton.impl;
 
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Sasl.SaslOutcome;
 import org.apache.qpid.proton.engine.Transport;

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
@@ -28,6 +28,7 @@ import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticator {
 
   private Sasl sasl;
+  private boolean succeeded;
 
   @Override
   public void init(Transport transport) {
@@ -35,6 +36,7 @@ public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticato
     sasl.server();
     sasl.allowSkip(false);
     sasl.setMechanisms(ProtonSaslAnonymousImpl.MECH_NAME);
+    succeeded = false;
   }
 
   @Override
@@ -48,6 +50,7 @@ public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticato
       String chosen = remoteMechanisms[0];
       if (ProtonSaslAnonymousImpl.MECH_NAME.equals(chosen)) {
         sasl.done(SaslOutcome.PN_SASL_OK);
+        succeeded = true;
         return true;
       } else {
         sasl.done(SaslOutcome.PN_SASL_AUTH);
@@ -55,5 +58,10 @@ public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticato
     }
 
     return false;
+  }
+
+  @Override
+  public boolean succeeded() {
+    return succeeded;
   }
 }

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslServerAuthenticatorImpl.java
@@ -19,8 +19,6 @@ import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Sasl.SaslOutcome;
 import org.apache.qpid.proton.engine.Transport;
 
-import io.vertx.core.Handler;
-import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 
 /**
@@ -29,13 +27,6 @@ import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticator {
 
   private Sasl sasl;
-  private Handler<ProtonConnection> handler;
-  private ProtonConnectionImpl connection;
-
-  public ProtonSaslServerAuthenticatorImpl(Handler<ProtonConnection> handler, ProtonConnectionImpl connection) {
-    this.handler = handler;
-    this.connection = connection;
-  }
 
   @Override
   public void init(Transport transport) {
@@ -56,7 +47,6 @@ public class ProtonSaslServerAuthenticatorImpl implements ProtonSaslAuthenticato
       String chosen = remoteMechanisms[0];
       if (ProtonSaslAnonymousImpl.MECH_NAME.equals(chosen)) {
         sasl.done(SaslOutcome.PN_SASL_OK);
-        handler.handle(connection);
         return true;
       } else {
         sasl.done(SaslOutcome.PN_SASL_AUTH);

--- a/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
@@ -38,28 +38,17 @@ public class ProtonServerImpl implements ProtonServer {
   private final Vertx vertx;
   private final NetServer server;
   private Handler<ProtonConnection> handler;
-  private final ProtonSaslAuthenticator authenticator;
+  private ProtonSaslAuthenticator authenticator;
   private boolean advertiseAnonymousRelayCapability = true;
 
-  private ProtonServerImpl(Vertx vertx, NetServer server, ProtonSaslAuthenticator authenticator) {
-    this.vertx = vertx;
-    this.server = server;
-    this.authenticator = authenticator;
-  }
   public ProtonServerImpl(Vertx vertx) {
-    this(vertx, vertx.createNetServer(), null);
-  }
-
-  public ProtonServerImpl(Vertx vertx, ProtonSaslAuthenticator authenticator) {
-    this(vertx, vertx.createNetServer(), authenticator);
+    this.vertx = vertx;
+    this.server = this.vertx.createNetServer();
   }
 
   public ProtonServerImpl(Vertx vertx, ProtonServerOptions options) {
-    this(vertx, vertx.createNetServer(options), null);
-  }
-
-  public ProtonServerImpl(Vertx vertx, ProtonServerOptions options, ProtonSaslAuthenticator authenticator) {
-    this(vertx, vertx.createNetServer(options), authenticator);
+    this.vertx = vertx;
+    this.server = this.vertx.createNetServer(options);
   }
 
   public int actualPort() {
@@ -120,6 +109,11 @@ public class ProtonServerImpl implements ProtonServer {
 
   public Handler<ProtonConnection> connectHandler() {
     return handler;
+  }
+
+  public ProtonServer saslAuthenticator(ProtonSaslAuthenticator authenticator) {
+    this.authenticator = authenticator;
+    return this;
   }
 
   public ProtonServerImpl connectHandler(Handler<ProtonConnection> handler) {

--- a/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
@@ -19,6 +19,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import io.vertx.core.*;
+import io.vertx.core.net.NetSocket;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.amqp.Symbol;
 
@@ -138,8 +139,8 @@ public class ProtonServerImpl implements ProtonServer {
       connection.bindServer(netSocket, new ProtonSaslAuthenticator () {
 
         @Override
-        public void init(ProtonConnection protonConnection, Transport transport) {
-          authenticator.init(protonConnection, transport);
+        public void init(NetSocket socket, ProtonConnection protonConnection, Transport transport) {
+          authenticator.init(socket, protonConnection, transport);
         }
 
         @Override

--- a/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
@@ -127,6 +127,7 @@ public class ProtonServerImpl implements ProtonServer {
       try {
         hostname = InetAddress.getLocalHost().getHostName();
       } catch (UnknownHostException e) {
+        // ignore
       }
 
       final ProtonConnectionImpl connection = new ProtonConnectionImpl(vertx, hostname);
@@ -137,8 +138,8 @@ public class ProtonServerImpl implements ProtonServer {
       connection.bindServer(netSocket, new ProtonSaslAuthenticator () {
 
         @Override
-        public void init(Transport transport) {
-          authenticator.init(transport);
+        public void init(ProtonConnection protonConnection, Transport transport) {
+          authenticator.init(protonConnection, transport);
         }
 
         @Override

--- a/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
@@ -18,6 +18,7 @@ package io.vertx.proton.impl;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.amqp.Symbol;
 
 import io.vertx.core.AsyncResult;

--- a/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
@@ -149,12 +149,10 @@ public class ProtonServerImpl implements ProtonServer {
             if (succeeded()) {
               handler.handle(connection);
             } else {
-              // auth failed, disconnect client
+              // auth failed, flush any pending data and disconnect client
+              connection.flush();
               connection.disconnect();
             }
-          } else {
-            // authentication is not complete, flush and wait for more data
-            connection.flush();
           }
           return result;
         }

--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -23,6 +23,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetSocket;
 
+import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
@@ -65,7 +66,7 @@ class ProtonTransport extends BaseHandler {
     transport.setMaxFrameSize(1024 * 32); // TODO: make configurable
     transport.setEmitFlowEventOnSend(false); // TODO: make configurable
     if (authenticator != null) {
-      authenticator.init(transport);
+      authenticator.init((ProtonConnection) this.connection.getContext(), transport);
     }
     this.authenticator = authenticator;
     transport.bind(connection);

--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -66,7 +66,7 @@ class ProtonTransport extends BaseHandler {
     transport.setMaxFrameSize(1024 * 32); // TODO: make configurable
     transport.setEmitFlowEventOnSend(false); // TODO: make configurable
     if (authenticator != null) {
-      authenticator.init((ProtonConnection) this.connection.getContext(), transport);
+      authenticator.init(this.socket, (ProtonConnection) this.connection.getContext(), transport);
     }
     this.authenticator = authenticator;
     transport.bind(connection);

--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -23,6 +23,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetSocket;
 
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Collector;

--- a/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
+++ b/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
@@ -15,12 +15,13 @@
 */
 package io.vertx.proton.sasl;
 
+import io.vertx.core.net.NetSocket;
 import io.vertx.proton.ProtonConnection;
 import org.apache.qpid.proton.engine.Transport;
 
 public interface ProtonSaslAuthenticator {
 
-  void init(ProtonConnection protonConnection, Transport transport);
+  void init(NetSocket socket, ProtonConnection protonConnection, Transport transport);
 
   /**
    * Process the SASL authentication cycle until such time as an outcome is determined. This should be called by the

--- a/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
+++ b/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package io.vertx.proton.impl;
+package io.vertx.proton.sasl;
 
 import org.apache.qpid.proton.engine.Transport;
 

--- a/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
+++ b/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
@@ -28,4 +28,11 @@ public interface ProtonSaslAuthenticator {
    * @return true if the SASL handshake completed.
    */
   boolean process();
+
+  /**
+   * Once called after process finished it returns true if the authentication succeeded.
+   *
+   * @return true if auth succeeded
+   */
+  boolean succeeded();
 }

--- a/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
+++ b/src/main/java/io/vertx/proton/sasl/ProtonSaslAuthenticator.java
@@ -15,11 +15,12 @@
 */
 package io.vertx.proton.sasl;
 
+import io.vertx.proton.ProtonConnection;
 import org.apache.qpid.proton.engine.Transport;
 
 public interface ProtonSaslAuthenticator {
 
-  void init(Transport transport);
+  void init(ProtonConnection protonConnection, Transport transport);
 
   /**
    * Process the SASL authentication cycle until such time as an outcome is determined. This should be called by the

--- a/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
@@ -16,6 +16,7 @@
 package io.vertx.proton.impl;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.net.NetSocket;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -36,7 +37,7 @@ public class ProtonServerImplTest {
         Vertx vertx = Vertx.vertx();
         ProtonServer.create(vertx).saslAuthenticator(new ProtonSaslAuthenticator() {
             @Override
-            public void init(ProtonConnection protonConnection, Transport transport) {
+            public void init(NetSocket socket, ProtonConnection protonConnection, Transport transport) {
                 async.complete();
             }
 

--- a/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
@@ -20,6 +20,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.proton.ProtonClient;
+import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.ProtonServer;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Transport;
@@ -35,7 +36,7 @@ public class ProtonServerImplTest {
         Vertx vertx = Vertx.vertx();
         ProtonServer.create(vertx).saslAuthenticator(new ProtonSaslAuthenticator() {
             @Override
-            public void init(Transport transport) {
+            public void init(ProtonConnection protonConnection, Transport transport) {
                 async.complete();
             }
 

--- a/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
@@ -1,0 +1,53 @@
+/*
+* Copyright 2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.proton.ProtonClient;
+import io.vertx.proton.ProtonServer;
+import org.apache.qpid.proton.engine.Transport;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ProtonServerImplTest {
+
+    @Test
+    public void shouldInvokePassedAuthenticator() throws InterruptedException {
+        // Given
+        Vertx vertx = Vertx.vertx();
+        ProtonSaslAuthenticator authenticator = mock(ProtonSaslAuthenticator.class);
+        ProtonServer.create(vertx, authenticator).connectHandler(protonConnection -> {}).listen(9999);
+
+        // When
+        ProtonClient.create(vertx).connect("localhost", 9999, protonConnectionAsyncResult -> {});
+
+        // Then
+        await().until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                verify(authenticator).init(any(Transport.class));
+                return true;
+            }
+        });
+    }
+
+}

--- a/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
@@ -43,6 +43,11 @@ public class ProtonServerImplTest {
             public boolean process() {
                 return false;
             }
+
+            @Override
+            public boolean succeeded() {
+                return false;
+            }
         }).connectHandler(protonConnection -> {}).listen(server ->
                 ProtonClient.create(vertx).connect("localhost", server.result().actualPort(),
                         protonConnectionAsyncResult -> {})

--- a/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonServerImplTest.java
@@ -21,6 +21,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.proton.ProtonClient;
 import io.vertx.proton.ProtonServer;
+import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Transport;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Follow up on #24 

I think what @gemmellr says is missing is a way to delegate the connection back to the server once a custom SASL auth completes.