### PR TITLE
Added "heartbeat" (AMQP idle-time-out) to Proton client and server options ...

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -19,7 +19,7 @@ To use Vert.x Proton, add the following dependency to the _dependencies_ section
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-proton</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -27,7 +27,7 @@ To use Vert.x Proton, add the following dependency to the _dependencies_ section
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-proton:3.3.3
+compile io.vertx:vertx-proton:3.4.0-SNAPSHOT
 ----
 
 === Creating a connection

--- a/src/main/java/io/vertx/proton/ProtonClientOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonClientOptions.java
@@ -39,6 +39,8 @@ public class ProtonClientOptions extends NetClientOptions {
 
   private Set<String> enabledSaslMechanisms = new LinkedHashSet<>();
 
+  private int heartbeat;
+
   public ProtonClientOptions() {
     super();
     setHostnameVerificationAlgorithm("HTTPS");
@@ -210,6 +212,7 @@ public class ProtonClientOptions extends NetClientOptions {
 
     int result = super.hashCode();
     result = prime * result + Objects.hashCode(enabledSaslMechanisms);
+    result = prime * result + this.heartbeat;
 
     return result;
   }
@@ -230,6 +233,9 @@ public class ProtonClientOptions extends NetClientOptions {
 
     ProtonClientOptions other = (ProtonClientOptions) obj;
     if (!Objects.equals(enabledSaslMechanisms, other.enabledSaslMechanisms)){
+      return false;
+    }
+    if (this.heartbeat != other.heartbeat) {
       return false;
     }
 
@@ -299,5 +305,26 @@ public class ProtonClientOptions extends NetClientOptions {
   public ProtonClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     super.setSslEngineOptions(sslEngineOptions);
     return this;
+  }
+
+  /**
+   * Set the heartbeat (in milliseconds) as maximum delay between sending frames for the remote peers.
+   * If no frames are received within 2*heartbeat, the connection is closed
+   *
+   * @param heartbeat hearthbeat maximum delay
+   * @return  current ProtonClientOptions instance
+   */
+  public ProtonClientOptions setHeartbeat(int heartbeat) {
+    this.heartbeat = heartbeat;
+    return this;
+  }
+
+  /**
+   * Return the heartbeat (in milliseconds) as maximum delay between sending frames for the remote peers.
+   *
+   * @return  hearthbeat maximum delay
+   */
+  public int getHeartbeat() {
+    return this.heartbeat;
   }
 }

--- a/src/main/java/io/vertx/proton/ProtonServerOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonServerOptions.java
@@ -28,10 +28,14 @@ import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.TrustOptions;
 
+import java.util.Objects;
+
 /**
  * Options for configuring {@link io.vertx.proton.ProtonServer} creation.
  */
 public class ProtonServerOptions extends NetServerOptions {
+
+  private int heartbeat;
 
   @Override
   public ProtonServerOptions setSendBufferSize(int sendBufferSize) {
@@ -180,12 +184,34 @@ public class ProtonServerOptions extends NetServerOptions {
 
   @Override
   public int hashCode() {
-    return super.hashCode();
+    final int prime = 31;
+
+    int result = super.hashCode();
+    result = prime * result + this.heartbeat;
+
+    return result;
   }
 
   @Override
   public boolean equals(Object obj) {
-    return super.equals(obj);
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null || getClass() != obj.getClass()){
+      return false;
+    }
+
+    if (!super.equals(obj)) {
+      return false;
+    }
+
+    ProtonServerOptions other = (ProtonServerOptions) obj;
+    if (this.heartbeat != other.heartbeat) {
+      return false;
+    }
+
+    return true;
   }
 
   @Override
@@ -227,5 +253,26 @@ public class ProtonServerOptions extends NetServerOptions {
   public ProtonServerOptions setTrustOptions(TrustOptions options) {
     super.setTrustOptions(options);
     return this;
+  }
+
+  /**
+   * Set the heartbeat (in milliseconds) as maximum delay between sending frames for the remote peers.
+   * If no frames are received within 2*heartbeat, the connection is closed
+   *
+   * @param heartbeat hearthbeat maximum delay
+   * @return  current ProtonServerOptions instance
+   */
+  public ProtonServerOptions setHeartbeat(int heartbeat) {
+    this.heartbeat = heartbeat;
+    return this;
+  }
+
+  /**
+   * Return the heartbeat (in milliseconds) as maximum delay between sending frames for the remote peers.
+   *
+   * @return  hearthbeat maximum delay
+   */
+  public int getHeartbeat() {
+    return this.heartbeat;
   }
 }

--- a/src/main/java/io/vertx/proton/ProtonTransportOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonTransportOptions.java
@@ -1,0 +1,70 @@
+/*
+* Copyright 2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton;
+
+/**
+ * Options for configuring transport layer
+ */
+public class ProtonTransportOptions {
+
+  private int heartbeat;
+
+  /**
+   * Set the heartbeat as maximum delay between sending frames for the remote peers.
+   * If no frames are received within 2*heartbeat, the connection is closed
+   *
+   * @param heartbeat hearthbeat maximum delay
+   * @return  current ProtonTransportOptions instance
+   */
+  public ProtonTransportOptions setHeartbeat(int heartbeat) {
+    this.heartbeat = heartbeat;
+    return this;
+  }
+
+  /**
+   * Return the heartbeat as maximum delay between sending frames for the remote peers.
+   *
+   * @return  hearthbeat maximum delay
+   */
+  public int getHeartbeat() {
+    return this.heartbeat;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = this.heartbeat;
+
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null || getClass() != obj.getClass()){
+      return false;
+    }
+
+    ProtonTransportOptions other = (ProtonTransportOptions) obj;
+    if (this.heartbeat != other.heartbeat) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
@@ -23,6 +23,7 @@ import io.vertx.core.net.NetClient;
 import io.vertx.proton.ProtonClient;
 import io.vertx.proton.ProtonClientOptions;
 import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonTransportOptions;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -64,7 +65,11 @@ public class ProtonClientImpl implements ProtonClient {
 
         ProtonSaslClientAuthenticatorImpl authenticator = new ProtonSaslClientAuthenticatorImpl(username, password,
                 options.getEnabledSaslMechanisms(), connectHandler);
-        amqpConnnection.bindClient(netClient, res.result(), authenticator);
+
+        ProtonTransportOptions transportOptions = new ProtonTransportOptions();
+        transportOptions.setHeartbeat(options.getHeartbeat());
+
+        amqpConnnection.bindClient(netClient, res.result(), authenticator, transportOptions);
 
         // Need to flush here to get the SASL process going, or it will wait until calls on the connection are processed
         // later (e.g open()).

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -15,14 +15,22 @@
 */
 package io.vertx.proton.impl;
 
-import static io.vertx.proton.ProtonHelper.future;
-
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetSocket;
+import io.vertx.proton.ProtonClientOptions;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonLinkOptions;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+import io.vertx.proton.ProtonServerOptions;
+import io.vertx.proton.ProtonSession;
+import io.vertx.proton.ProtonTransportOptions;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
@@ -35,19 +43,13 @@ import org.apache.qpid.proton.engine.Record;
 import org.apache.qpid.proton.engine.Sender;
 import org.apache.qpid.proton.engine.Session;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetSocket;
-import io.vertx.proton.ProtonConnection;
-import io.vertx.proton.ProtonReceiver;
-import io.vertx.proton.ProtonSender;
-import io.vertx.proton.ProtonSession;
-import io.vertx.proton.ProtonLinkOptions;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.vertx.proton.ProtonHelper.future;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -371,12 +373,12 @@ public class ProtonConnectionImpl implements ProtonConnection {
     }
   }
 
-  void bindClient(NetClient client, NetSocket socket, ProtonSaslClientAuthenticatorImpl authenticator) {
-    transport = new ProtonTransport(connection, vertx, client, socket, authenticator);
+  void bindClient(NetClient client, NetSocket socket, ProtonSaslClientAuthenticatorImpl authenticator, ProtonTransportOptions transportOptions) {
+    transport = new ProtonTransport(connection, vertx, client, socket, authenticator, transportOptions);
   }
 
-  void bindServer(NetSocket socket, ProtonSaslAuthenticator authenticator) {
-    transport = new ProtonTransport(connection, vertx, null, socket, authenticator);
+  void bindServer(NetSocket socket, ProtonSaslAuthenticator authenticator, ProtonTransportOptions transportOptions) {
+    transport = new ProtonTransport(connection, vertx, null, socket, authenticator, transportOptions);
   }
 
   void fireRemoteSessionOpen(Session session) {

--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -24,6 +24,7 @@ import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetSocket;
 
 import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonTransportOptions;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.engine.BaseHandler;
@@ -58,13 +59,14 @@ class ProtonTransport extends BaseHandler {
   private boolean failed;
 
   ProtonTransport(Connection connection, Vertx vertx, NetClient netClient, NetSocket socket,
-      ProtonSaslAuthenticator authenticator) {
+                  ProtonSaslAuthenticator authenticator, ProtonTransportOptions options) {
     this.connection = connection;
     this.vertx = vertx;
     this.netClient = netClient;
     this.socket = socket;
     transport.setMaxFrameSize(1024 * 32); // TODO: make configurable
     transport.setEmitFlowEventOnSend(false); // TODO: make configurable
+    transport.setIdleTimeout(2 * options.getHeartbeat());
     if (authenticator != null) {
       authenticator.init(this.socket, (ProtonConnection) this.connection.getContext(), transport);
     }

--- a/src/test/java/io/vertx/proton/ProtonClientOptionsTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientOptionsTest.java
@@ -106,4 +106,14 @@ public class ProtonClientOptionsTest {
     options.setHostnameVerificationAlgorithm("HTTPS");
     assertEquals("Expected algorthim value not found", "HTTPS", options.getHostnameVerificationAlgorithm());
   }
+
+  @Test
+  public void testHeartbeat() {
+    ProtonClientOptions options = new ProtonClientOptions();
+
+    options.setHeartbeat(1000);
+    assertEquals(options.getHeartbeat(), 1000);
+    options.setHeartbeat(2000);
+    assertNotEquals(options.getHeartbeat(), 1000);
+  }
 }

--- a/src/test/java/io/vertx/proton/ProtonServerOptionsTest.java
+++ b/src/test/java/io/vertx/proton/ProtonServerOptionsTest.java
@@ -1,0 +1,89 @@
+/*
+* Copyright 2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ProtonServerOptionsTest {
+
+  @Test
+  public void testEqualsItself() {
+    ProtonServerOptions options = new ProtonServerOptions();
+
+    assertEquals("Options should be equal to itself", options, options);
+  }
+
+  @Test
+  public void testDifferentObjectsEqual() {
+    ProtonServerOptions options1 = new ProtonServerOptions();
+    options1.setHeartbeat(1000);
+    ProtonServerOptions options2 = new ProtonServerOptions();
+    options2.setHeartbeat(1000);
+
+    assertNotSame("Options should be different objects", options1, options2);
+    assertEquals("Options should be equal", options1, options2);
+  }
+
+  @Test
+  public void testDifferentObjectsNotEqual() {
+    ProtonServerOptions options1 = new ProtonServerOptions();
+    options1.setHeartbeat(1000);
+    ProtonServerOptions options2 = new ProtonServerOptions();
+    options2.setHeartbeat(2000);
+
+    assertNotSame("Options should be different objects", options1, options2);
+    assertNotEquals("Options should not be equal", options1, options2);
+  }
+
+  @Test
+  public void testEqualObjectsReturnSameHashCode() {
+    ProtonServerOptions options1 = new ProtonServerOptions();
+    options1.setHeartbeat(1000);
+    ProtonServerOptions options2 = new ProtonServerOptions();
+    options2.setHeartbeat(1000);
+
+    assertNotSame("Options should be different objects", options1, options2);
+    assertEquals("Options should be equal", options1, options2);
+    assertEquals("Options should have same hash code", options1.hashCode(), options2.hashCode());
+  }
+
+  @Test
+  public void testEqualsNull() {
+    ProtonServerOptions options = new ProtonServerOptions();
+
+    assertFalse("Options should not equal null", options.equals(null));
+  }
+
+  @Test
+  public void testHashCodeReturnsSameValueOnRepeatedCall() {
+    ProtonServerOptions options = new ProtonServerOptions();
+    options.setHeartbeat(1000);
+
+    assertEquals("Options should have same hash code for both calls", options.hashCode(), options.hashCode());
+  }
+
+  @Test
+  public void testHeartbeat() {
+    ProtonServerOptions options = new ProtonServerOptions();
+
+    options.setHeartbeat(1000);
+    assertEquals(options.getHeartbeat(), 1000);
+    options.setHeartbeat(2000);
+    assertNotEquals(options.getHeartbeat(), 1000);
+  }
+}

--- a/src/test/java/io/vertx/proton/ProtonTransportOptionsTest.java
+++ b/src/test/java/io/vertx/proton/ProtonTransportOptionsTest.java
@@ -1,0 +1,91 @@
+/*
+* Copyright 2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ProtonTransportOptionsTest {
+
+  @Test
+  public void testEqualsItself() {
+    ProtonTransportOptions options = new ProtonTransportOptions();
+
+    assertEquals("Options should be equal to itself", options, options);
+  }
+
+  @Test
+  public void testDifferentObjectsEqual() {
+    ProtonTransportOptions options1 = new ProtonTransportOptions();
+    options1.setHeartbeat(1000);
+    ProtonTransportOptions options2 = new ProtonTransportOptions();
+    options2.setHeartbeat(1000);
+
+    assertNotSame("Options should be different objects", options1, options2);
+    assertEquals("Options should be equal", options1, options2);
+  }
+
+  @Test
+  public void testDifferentObjectsNotEqual() {
+    ProtonTransportOptions options1 = new ProtonTransportOptions();
+    options1.setHeartbeat(1000);
+    ProtonTransportOptions options2 = new ProtonTransportOptions();
+    options2.setHeartbeat(2000);
+
+    assertNotSame("Options should be different objects", options1, options2);
+    assertNotEquals("Options should not be equal", options1, options2);
+  }
+
+  @Test
+  public void testEqualObjectsReturnSameHashCode() {
+    ProtonTransportOptions options1 = new ProtonTransportOptions();
+    options1.setHeartbeat(1000);
+    ProtonTransportOptions options2 = new ProtonTransportOptions();
+    options2.setHeartbeat(1000);
+
+    assertNotSame("Options should be different objects", options1, options2);
+    assertEquals("Options should be equal", options1, options2);
+    assertEquals("Options should have same hash code", options1.hashCode(), options2.hashCode());
+  }
+
+  @Test
+  public void testEqualsNull() {
+    ProtonTransportOptions options = new ProtonTransportOptions();
+
+    assertFalse("Options should not equal null", options.equals(null));
+  }
+
+  @Test
+  public void testHashCodeReturnsSameValueOnRepeatedCall() {
+    ProtonTransportOptions options = new ProtonTransportOptions();
+    options.setHeartbeat(1000);
+
+    assertEquals("Options should have same hash code for both calls", options.hashCode(), options.hashCode());
+  }
+
+  @Test
+  public void testHeartbeat() {
+    ProtonTransportOptions options = new ProtonTransportOptions();
+
+    options.setHeartbeat(1000);
+    assertEquals(options.getHeartbeat(), 1000);
+    options.setHeartbeat(2000);
+    assertNotEquals(options.getHeartbeat(), 1000);
+  }
+}


### PR DESCRIPTION
Modified Proton client and server implementation in order to handle above new parameter
Added unit tests for Proton server options
Added test on "heartbeat" to unit tests for Proton client options

This is related to #34 