### PR TITLE
add options for specifying the virtual host and/or SNI server-name details to use

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonClientOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonClientOptions.java
@@ -40,6 +40,8 @@ public class ProtonClientOptions extends NetClientOptions {
   private Set<String> enabledSaslMechanisms = new LinkedHashSet<>();
 
   private int heartbeat;
+  private String virtualHost;
+  private String sniServerName;
 
   public ProtonClientOptions() {
     super();
@@ -213,6 +215,8 @@ public class ProtonClientOptions extends NetClientOptions {
     int result = super.hashCode();
     result = prime * result + Objects.hashCode(enabledSaslMechanisms);
     result = prime * result + this.heartbeat;
+    result = prime * result + (this.virtualHost != null ? this.virtualHost.hashCode() : 0);
+    result = prime * result + (this.sniServerName != null ? this.sniServerName.hashCode() : 0);
 
     return result;
   }
@@ -236,6 +240,12 @@ public class ProtonClientOptions extends NetClientOptions {
       return false;
     }
     if (this.heartbeat != other.heartbeat) {
+      return false;
+    }
+    if (!Objects.equals(this.virtualHost, other.virtualHost)) {
+      return false;
+    }
+    if (!Objects.equals(this.sniServerName, other.sniServerName)) {
       return false;
     }
 
@@ -311,6 +321,52 @@ public class ProtonClientOptions extends NetClientOptions {
   public ProtonClientOptions setLocalAddress(String localAddress) {
     super.setLocalAddress(localAddress);
     return this;
+  }
+
+  /**
+   * Override the host to use in the connection open frame and the SNI server name. The SNI server name can be changed
+   * explicitly using {@link #setSniServerName(String)}. By default, the hostname specified in
+   * {@link ProtonClient#connect} will be used.
+   *
+   * @param virtualHost hostname to set
+   * @return  current ProtonClientOptions instance
+   */
+  public ProtonClientOptions setVirtualHost(String virtualHost) {
+    this.virtualHost = virtualHost;
+    return this;
+  }
+
+  /**
+   * Return the host override for the connection open frame.
+   *
+   * @return  the hostname
+   */
+  public String getVirtualHost() {
+    return this.virtualHost;
+  }
+
+  /**
+   * Override the host to use for the SNI server name. The SNI server name will also be set by calling
+   * @link #setVirtualHost(String)}. This method should be used only when you need to set the virtual host and SNI
+   * server name to different values. If neither the virtual host or SNI server name is set, the hostname
+   * specified in {@link ProtonClient#connect} will be used as the SNI server name.
+   *
+   * @param sniServerName hostname to set as SNI server name
+   * @return  current ProtonClientOptions instance
+   */
+  public ProtonClientOptions setSniServerName(String sniServerName) {
+    this.sniServerName = sniServerName;
+    return this;
+  }
+
+  /**
+   * Return the host override for SNI Server Name. The value can either be set from {@link #setVirtualHost(String)} or
+   * {@link #setSniServerName(String)}.
+   *
+   * @return  the hostname
+   */
+  public String getSniServerName() {
+    return this.sniServerName;
   }
 
   /**

--- a/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
@@ -25,6 +25,7 @@ import io.vertx.core.VertxException;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetSocket;
 import io.vertx.proton.ProtonClient;
 import io.vertx.proton.ProtonClientOptions;
 import io.vertx.proton.ProtonConnection;
@@ -65,9 +66,14 @@ public class ProtonClientImpl implements ProtonClient {
 
   private void connectNetClient(NetClient netClient, String host, int port, String username, String password,
                                 ConnectCompletionHandler connectHandler, ProtonClientOptions options) {
-    netClient.connect(port, host, res -> {
+
+    String serverName = options.getSniServerName() != null ? options.getSniServerName() :
+      (options.getVirtualHost() != null ? options.getVirtualHost() : null);
+
+    netClient.connect(port, host, serverName, res -> {
       if (res.succeeded()) {
-        ProtonConnectionImpl conn = new ProtonConnectionImpl(vertx, host);
+        String virtualHost = options.getVirtualHost() != null ? options.getVirtualHost() : host;
+        ProtonConnectionImpl conn = new ProtonConnectionImpl(vertx, virtualHost);
         conn.disconnectHandler(h -> {
           LOG.trace("Connection disconnected");
           if(!connectHandler.isComplete()) {

--- a/src/test/java/io/vertx/proton/MockServerTestBase.java
+++ b/src/test/java/io/vertx/proton/MockServerTestBase.java
@@ -77,4 +77,12 @@ abstract public class MockServerTestBase {
       handler.handle(res.result());
     });
   }
+
+  protected void connect(TestContext context, ProtonClientOptions options, Handler<ProtonConnection> handler) {
+    ProtonClient client = ProtonClient.create(vertx);
+    client.connect(options, "localhost", server.actualPort(), res -> {
+      context.assertTrue(res.succeeded());
+      handler.handle(res.result());
+    });
+  }
 }

--- a/src/test/java/io/vertx/proton/ProtonClientOptionsTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientOptionsTest.java
@@ -116,4 +116,22 @@ public class ProtonClientOptionsTest {
     options.setHeartbeat(2000);
     assertNotEquals(options.getHeartbeat(), 1000);
   }
+
+  @Test
+  public void testVirtualHost() {
+    ProtonClientOptions options = new ProtonClientOptions();
+    options.setVirtualHost("example.com");
+    assertEquals("example.com", options.getVirtualHost());
+    options.setVirtualHost("another.example.com");
+    assertEquals("another.example.com", options.getVirtualHost());
+  }
+
+  @Test
+  public void testSniServerName() {
+    ProtonClientOptions options = new ProtonClientOptions();
+    options.setSniServerName("example.com");
+    assertEquals("example.com", options.getSniServerName());
+    options.setSniServerName("another.example.com");
+    assertEquals("another.example.com", options.getSniServerName());
+  }
 }

--- a/src/test/java/io/vertx/proton/ProtonClientTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientTest.java
@@ -174,6 +174,18 @@ public class ProtonClientTest extends MockServerTestBase {
   }
 
   @Test(timeout = 20000)
+  public void testSetVirtualHostOnConnect(TestContext context) {
+    Async async = context.async();
+    ProtonClientOptions options = new ProtonClientOptions()
+      .setVirtualHost("example.com");
+    connect(context, options, connection -> {
+      context.assertFalse(connection.isDisconnected());
+      context.assertEquals("example.com", connection.getHostname());
+      async.complete();
+    });
+  }
+
+  @Test(timeout = 20000)
   public void testRequestResponse(TestContext context) {
     sendReceiveEcho(context, "Hello World");
   }


### PR DESCRIPTION
* Without SSL, this will set the hostname for the AMQP container to
the virtualHost
* With SSL, this will set the host name for the AMQP container and the
SNI header in the TLS handshake

This is using a new API on NetClient from https://github.com/eclipse/vert.x/pull/1954 (not merged)