### PR TITLE
Make max-frame-size used in AMQP OPEN frame configurable.

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonClientOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonClientOptions.java
@@ -40,6 +40,7 @@ public class ProtonClientOptions extends NetClientOptions {
   private Set<String> enabledSaslMechanisms = new LinkedHashSet<>();
 
   private int heartbeat;
+  private int maxFrameSize;
   private String virtualHost;
   private String sniServerName;
 
@@ -215,6 +216,7 @@ public class ProtonClientOptions extends NetClientOptions {
     int result = super.hashCode();
     result = prime * result + Objects.hashCode(enabledSaslMechanisms);
     result = prime * result + this.heartbeat;
+    result = prime * result + this.maxFrameSize;
     result = prime * result + (this.virtualHost != null ? this.virtualHost.hashCode() : 0);
     result = prime * result + (this.sniServerName != null ? this.sniServerName.hashCode() : 0);
 
@@ -242,6 +244,9 @@ public class ProtonClientOptions extends NetClientOptions {
     if (this.heartbeat != other.heartbeat) {
       return false;
     }
+    if (this.maxFrameSize != other.maxFrameSize) {
+        return false;
+      }
     if (!Objects.equals(this.virtualHost, other.virtualHost)) {
       return false;
     }
@@ -393,5 +398,35 @@ public class ProtonClientOptions extends NetClientOptions {
    */
   public int getHeartbeat() {
     return this.heartbeat;
+  }
+
+  /**
+   * Sets the maximum frame size to announce in the AMQP <em>OPEN</em> frame.
+   * <p>
+   * If this property is not set explicitly, a reasonable default value is used.
+   * <p>
+   * Setting this property to a negative value will result in no maximum frame size being announced at all.
+   * 
+   * @param maxFrameSize The frame size in bytes.
+   * @return This instance for setter chaining.
+   */
+  public ProtonClientOptions setMaxFrameSize(int maxFrameSize) {
+    if (maxFrameSize < 0) {
+      this.maxFrameSize = -1;
+    } else {
+      this.maxFrameSize = maxFrameSize;
+    }
+    return this;
+  }
+
+  /**
+   * Gets the maximum frame size to announce in the AMQP <em>OPEN</em> frame.
+   * <p>
+   * If this property is not set explicitly, a reasonable default value is used.
+   * 
+   * @return The frame size in bytes or -1 if no limit is set.
+   */
+  public int getMaxFrameSize() {
+    return maxFrameSize;
   }
 }

--- a/src/main/java/io/vertx/proton/ProtonServerOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonServerOptions.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 the original author or authors.
+* Copyright 2016, 2017 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import io.vertx.core.net.TrustOptions;
 public class ProtonServerOptions extends NetServerOptions {
 
   private int heartbeat;
+  private int maxFrameSize;
 
   @Override
   public ProtonServerOptions setSendBufferSize(int sendBufferSize) {
@@ -186,6 +187,7 @@ public class ProtonServerOptions extends NetServerOptions {
 
     int result = super.hashCode();
     result = prime * result + this.heartbeat;
+    result = prime * result + this.maxFrameSize;
 
     return result;
   }
@@ -208,6 +210,9 @@ public class ProtonServerOptions extends NetServerOptions {
     if (this.heartbeat != other.heartbeat) {
       return false;
     }
+    if (this.maxFrameSize != other.maxFrameSize) {
+        return false;
+      }
 
     return true;
   }
@@ -266,11 +271,11 @@ public class ProtonServerOptions extends NetServerOptions {
   }
 
   /**
-   * Set the heartbeat (in milliseconds) as maximum delay between sending frames for the remote peers.
-   * If no frames are received within 2*heartbeat, the connection is closed
+   * Sets the heart beat (in milliseconds) as maximum delay between sending frames for the remote peers.
+   * If no frames are received within 2 * heart beat, the connection is closed.
    *
-   * @param heartbeat hearthbeat maximum delay
-   * @return  current ProtonServerOptions instance
+   * @param heartbeat heart beat maximum delay
+   * @return current ProtonServerOptions instance
    */
   public ProtonServerOptions setHeartbeat(int heartbeat) {
     this.heartbeat = heartbeat;
@@ -278,11 +283,41 @@ public class ProtonServerOptions extends NetServerOptions {
   }
 
   /**
-   * Return the heartbeat (in milliseconds) as maximum delay between sending frames for the remote peers.
+   * Gets the heart beat (in milliseconds) as maximum delay between sending frames for the remote peers.
    *
-   * @return  hearthbeat maximum delay
+   * @return heart beat maximum delay
    */
   public int getHeartbeat() {
     return this.heartbeat;
+  }
+
+  /**
+   * Sets the maximum frame size to announce in the AMQP <em>OPEN</em> frame.
+   * <p>
+   * If this property is not set explicitly, a reasonable default value is used.
+   * <p>
+   * Setting this property to a negative value will result in no maximum frame size being announced at all.
+   * 
+   * @param maxFrameSize The frame size in bytes.
+   * @return This instance for setter chaining.
+   */
+  public ProtonServerOptions setMaxFrameSize(int maxFrameSize) {
+    if (maxFrameSize < 0) {
+      this.maxFrameSize = -1;
+    } else {
+      this.maxFrameSize = maxFrameSize;
+    }
+    return this;
+  }
+
+  /**
+   * Gets the maximum frame size to announce in the AMQP <em>OPEN</em> frame.
+   * <p>
+   * If this property is not set explicitly, a reasonable default value is used.
+   * 
+   * @return The frame size in bytes or -1 if no limit is set.
+   */
+  public int getMaxFrameSize() {
+    return maxFrameSize;
   }
 }

--- a/src/main/java/io/vertx/proton/ProtonTransportOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonTransportOptions.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 the original author or authors.
+* Copyright 2016, 2017 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,13 +21,14 @@ package io.vertx.proton;
 public class ProtonTransportOptions {
 
   private int heartbeat;
+  private int maxFrameSize;
 
   /**
-   * Set the heartbeat as maximum delay between sending frames for the remote peers.
-   * If no frames are received within 2*heartbeat, the connection is closed
+   * Set the heart beat as maximum delay between sending frames for the remote peers.
+   * If no frames are received within 2 * heart beat, the connection is closed
    *
-   * @param heartbeat hearthbeat maximum delay
-   * @return  current ProtonTransportOptions instance
+   * @param heartbeat The maximum delay in milliseconds.
+   * @return current ProtonTransportOptions instance.
    */
   public ProtonTransportOptions setHeartbeat(int heartbeat) {
     this.heartbeat = heartbeat;
@@ -35,18 +36,50 @@ public class ProtonTransportOptions {
   }
 
   /**
-   * Return the heartbeat as maximum delay between sending frames for the remote peers.
+   * Returns the heart beat as maximum delay between sending frames for the remote peers.
    *
-   * @return  hearthbeat maximum delay
+   * @return The maximum delay in milliseconds.
    */
   public int getHeartbeat() {
     return this.heartbeat;
   }
 
+  /**
+   * Sets the maximum frame size to announce in the AMQP <em>OPEN</em> frame.
+   * <p>
+   * If this property is not set explicitly, a reasonable default value is used.
+   * <p>
+   * Setting this property to a negative value will result in no maximum frame size being announced at all.
+   * 
+   * @param maxFrameSize The frame size in bytes.
+   * @return This instance for setter chaining.
+   */
+  public ProtonTransportOptions setMaxFrameSize(int maxFrameSize) {
+    if (maxFrameSize < 0) {
+      this.maxFrameSize = -1;
+    } else {
+      this.maxFrameSize = maxFrameSize;
+    }
+    return this;
+  }
+
+  /**
+   * Gets the maximum frame size to announce in the AMQP <em>OPEN</em> frame.
+   * <p>
+   * If this property is not set explicitly, a reasonable default value is used.
+   * 
+   * @return The frame size in bytes or -1 if no limit is set.
+   */
+  public int getMaxFrameSize() {
+    return maxFrameSize;
+  }
+
   @Override
   public int hashCode() {
-    int result = this.heartbeat;
-
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + heartbeat;
+    result = prime * result + maxFrameSize;
     return result;
   }
 
@@ -64,6 +97,9 @@ public class ProtonTransportOptions {
     if (this.heartbeat != other.heartbeat) {
       return false;
     }
+    if (this.maxFrameSize != other.maxFrameSize) {
+        return false;
+      }
 
     return true;
   }

--- a/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonClientImpl.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 the original author or authors.
+* Copyright 2016, 2017 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,6 +86,7 @@ public class ProtonClientImpl implements ProtonClient {
 
         ProtonTransportOptions transportOptions = new ProtonTransportOptions();
         transportOptions.setHeartbeat(options.getHeartbeat());
+        transportOptions.setMaxFrameSize(options.getMaxFrameSize());
 
         conn.bindClient(netClient, res.result(), authenticator, transportOptions);
 

--- a/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonServerImpl.java
@@ -163,6 +163,7 @@ public class ProtonServerImpl implements ProtonServer {
 
       ProtonTransportOptions transportOptions = new ProtonTransportOptions();
       transportOptions.setHeartbeat(this.options.getHeartbeat());
+      transportOptions.setMaxFrameSize(this.options.getMaxFrameSize());
 
       connection.bindServer(netSocket, new ProtonSaslAuthenticator() {
 

--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 the original author or authors.
+* Copyright 2016, 2017 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
  */
 class ProtonTransport extends BaseHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ProtonTransport.class);
+  private static final int DEFAULT_MAX_FRAME_SIZE = 32 * 1024; // 32kb
 
   private final Connection connection;
   private final Vertx vertx;
@@ -64,7 +65,7 @@ class ProtonTransport extends BaseHandler {
     this.vertx = vertx;
     this.netClient = netClient;
     this.socket = socket;
-    transport.setMaxFrameSize(1024 * 32); // TODO: make configurable
+    transport.setMaxFrameSize(options.getMaxFrameSize() == 0 ? DEFAULT_MAX_FRAME_SIZE : options.getMaxFrameSize());
     transport.setEmitFlowEventOnSend(false); // TODO: make configurable
     transport.setIdleTimeout(2 * options.getHeartbeat());
     if (authenticator != null) {


### PR DESCRIPTION
Added maxFrameSize property to ProtonClientOptions, ProtonServerOptions
and ProtonTransportOptions which can be used to configure the
max-frame-size being announced in an AMQP OPEN frame.