### PR TITLE
Expose accessors for Link Properties and Connection/Link Capabilities

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonConnection.java
+++ b/src/main/java/io/vertx/proton/ProtonConnection.java
@@ -190,6 +190,45 @@ public interface ProtonConnection {
   String getRemoteContainer();
 
   /**
+   * Sets the desired connection capabilities to be sent to the remote peer in our Open frame.
+   *
+   * If non-null, the given array will be copied and augmented with any default capabilities. If null, no capabilities
+   * will be sent.
+   *
+   * @param capabilities
+   *          the capabilities, or null to request not sending any capabilities
+   * @return the connection
+   */
+  ProtonConnection setDesiredCapabilities(Symbol[] capabilities);
+
+  /**
+   * Returns the desired connection capabilities sent by the remote peer in its Open frame. May be null.
+   *
+   * @return the remote desired connection capabilities, or null if no capabilities were sent.
+   */
+  Symbol[] getRemoteDesiredCapabilities();
+
+  /**
+   * Sets the offered connection capabilities to be sent to the remote peer in our Open frame.
+   *
+   * If non-null, the given array will be copied and augmented with any default capabilities. If null, no capabilities
+   * will be sent.
+   *
+   * @param capabilities
+   *          the capabilities, or null to request not sending any capabilities
+   * @return the connection
+   */
+  ProtonConnection setOfferedCapabilities(Symbol[] capabilities);
+
+  /**
+   * Returns the offered connection capabilities sent by the remote peer in its Open frame. May be null.
+   *
+   * @return the remote offered connection capabilities, or null if no capabilities were sent.
+   */
+  Symbol[] getRemoteOfferedCapabilities();
+
+
+  /**
    * Returns the container value requested by/advertised by remote peer in their AMQP Open frame.
    *
    * @return the container id

--- a/src/main/java/io/vertx/proton/ProtonLink.java
+++ b/src/main/java/io/vertx/proton/ProtonLink.java
@@ -18,11 +18,14 @@ package io.vertx.proton;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedLong;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.amqp.transport.Source;
 import org.apache.qpid.proton.amqp.transport.Target;
 import org.apache.qpid.proton.engine.Record;
+
+import java.util.Map;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -264,4 +267,61 @@ public interface ProtonLink<T extends ProtonLink<T>> {
    * @return the remote max message size conveyed by the peer, or null if none was set. 0 also means no limit.
    */
   UnsignedLong getRemoteMaxMessageSize();
+
+
+  /**
+   * Sets the link properties, to be conveyed to the peer via the Attach frame
+   * when attaching the link to the session.
+   *
+   * Must be called during link setup, i.e. before calling the {@link #open()} method.
+   *
+   * @param properties the properties of the link to be coveyed to the remote peer.
+   */
+  void setProperties(Map<Symbol, Object> properties);
+
+  /**
+   * Gets the remote link properties, as conveyed from the peer via the Attach frame
+   * when attaching the link to the session.
+   *
+   * @return the remote link properties conveyed by the peer, or null if none was set.
+   */
+  Map<Symbol, Object> getRemoteProperties();
+
+
+  /**
+   * Sets the offered capabilities, to be conveyed to the peer via the Attach frame
+   * when attaching the link to the session.
+   *
+   * Must be called during link setup, i.e. before calling the {@link #open()} method.
+   *
+   * @param capabilities the capabilities offered to the remote peer.
+   */
+  void setOfferedCapabilities(Symbol[] capabilities);
+
+  /**
+   * Gets the remote offered capabilities, as conveyed from the peer via the Attach frame
+   * when attaching the link to the session.
+   *
+   * @return the remote offered capabilities conveyed by the peer, or null if none was set.
+   */
+  Symbol[] getRemoteOfferedCapabilities();
+
+  /**
+   * Sets the desired capabilities, to be conveyed to the peer via the Attach frame
+   * when attaching the link to the session.
+   *
+   * Must be called during link setup, i.e. before calling the {@link #open()} method.
+   *
+   * @param capabilities the capabilities desired of the remote peer.
+   */
+  void setDesiredCapabilities(Symbol[] capabilities);
+
+  /**
+   * Gets the remote desired capabilities, as conveyed from the peer via the Attach frame
+   * when attaching the link to the session.
+   *
+   * @return the remote desired capabilities conveyed by the peer, or null if none was set.
+   */
+  Symbol[] getRemoteDesiredCapabilities();
+
 }

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -42,9 +42,12 @@ import org.apache.qpid.proton.engine.Sender;
 import org.apache.qpid.proton.engine.Session;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static io.vertx.proton.ProtonHelper.future;
@@ -105,6 +108,10 @@ public class ProtonConnectionImpl implements ProtonConnection {
     return props;
   }
 
+  private Set<Symbol> createInitialOfferedCapabilities() {
+    return Collections.emptySet();
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   //
   // Delegated state tracking
@@ -123,6 +130,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
     return this;
   }
 
+  @Override
   public ProtonConnectionImpl setOfferedCapabilities(Symbol[] capabilities) {
     connection.setOfferedCapabilities(capabilities);
     return this;
@@ -134,6 +142,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
     return this;
   }
 
+  @Override
   public ProtonConnectionImpl setDesiredCapabilities(Symbol[] capabilities) {
     connection.setDesiredCapabilities(capabilities);
     return this;
@@ -180,6 +189,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
     return connection.getRemoteContainer();
   }
 
+  @Override
   public Symbol[] getRemoteDesiredCapabilities() {
     return connection.getRemoteDesiredCapabilities();
   }
@@ -189,6 +199,7 @@ public class ProtonConnectionImpl implements ProtonConnection {
     return connection.getRemoteHostname();
   }
 
+  @Override
   public Symbol[] getRemoteOfferedCapabilities() {
     return connection.getRemoteOfferedCapabilities();
   }

--- a/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonConnectionImpl.java
@@ -108,10 +108,6 @@ public class ProtonConnectionImpl implements ProtonConnection {
     return props;
   }
 
-  private Set<Symbol> createInitialOfferedCapabilities() {
-    return Collections.emptySet();
-  }
-
   /////////////////////////////////////////////////////////////////////////////
   //
   // Delegated state tracking

--- a/src/main/java/io/vertx/proton/impl/ProtonLinkImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonLinkImpl.java
@@ -21,6 +21,7 @@ import io.vertx.proton.ProtonHelper;
 import io.vertx.proton.ProtonLink;
 import io.vertx.proton.ProtonQoS;
 
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedLong;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
@@ -31,6 +32,7 @@ import org.apache.qpid.proton.engine.Delivery;
 import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Link;
 import org.apache.qpid.proton.engine.Record;
+import java.util.Map;
 
 /**
  * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
@@ -264,6 +266,40 @@ abstract class ProtonLinkImpl<T extends ProtonLink<T>> implements ProtonLink<T> 
   @Override
   public UnsignedLong getRemoteMaxMessageSize() {
     return link.getRemoteMaxMessageSize();
+  }
+
+  @Override
+  public Map<Symbol, Object> getRemoteProperties() {
+    return link.getRemoteProperties();
+  }
+
+  @Override
+  public void setProperties(Map<Symbol, Object> properties) {
+    link.setProperties(properties);
+  }
+
+  @Override
+  public void setOfferedCapabilities(final Symbol[] capabilities)
+  {
+    link.setOfferedCapabilities(capabilities);
+  }
+
+  @Override
+  public Symbol[] getRemoteOfferedCapabilities()
+  {
+    return link.getRemoteOfferedCapabilities();
+  }
+
+  @Override
+  public void setDesiredCapabilities(final Symbol[] capabilities)
+  {
+    link.setDesiredCapabilities(capabilities);
+  }
+
+  @Override
+  public Symbol[] getRemoteDesiredCapabilities()
+  {
+    return link.getRemoteDesiredCapabilities();
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/io/vertx/proton/impl/ProtonLinkImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonLinkImpl.java
@@ -279,26 +279,22 @@ abstract class ProtonLinkImpl<T extends ProtonLink<T>> implements ProtonLink<T> 
   }
 
   @Override
-  public void setOfferedCapabilities(final Symbol[] capabilities)
-  {
+  public void setOfferedCapabilities(final Symbol[] capabilities) {
     link.setOfferedCapabilities(capabilities);
   }
 
   @Override
-  public Symbol[] getRemoteOfferedCapabilities()
-  {
+  public Symbol[] getRemoteOfferedCapabilities() {
     return link.getRemoteOfferedCapabilities();
   }
 
   @Override
-  public void setDesiredCapabilities(final Symbol[] capabilities)
-  {
+  public void setDesiredCapabilities(final Symbol[] capabilities) {
     link.setDesiredCapabilities(capabilities);
   }
 
   @Override
-  public Symbol[] getRemoteDesiredCapabilities()
-  {
+  public Symbol[] getRemoteDesiredCapabilities() {
     return link.getRemoteDesiredCapabilities();
   }
 


### PR DESCRIPTION
In progress AMQP specifications such as [link pairing](https://www.oasis-open.org/committees/download.php/60237/linkpair-v1.0-wd01.docx) require access to link properties as well as connection capabilities.  These are currently not exposed via vertx-proton.