### PR TITLE
Add copy constructors

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonClientOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonClientOptions.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 the original author or authors.
+* Copyright 2016, 2017 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -47,6 +47,19 @@ public class ProtonClientOptions extends NetClientOptions {
   public ProtonClientOptions() {
     super();
     setHostnameVerificationAlgorithm("HTTPS");
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public ProtonClientOptions(ProtonClientOptions other) {
+    super(other);
+    this.heartbeat = other.heartbeat;
+    this.maxFrameSize = other.maxFrameSize;
+    this.virtualHost = other.virtualHost;
+    this.sniServerName = other.sniServerName;
   }
 
   /**

--- a/src/main/java/io/vertx/proton/ProtonServerOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonServerOptions.java
@@ -36,6 +36,15 @@ public class ProtonServerOptions extends NetServerOptions {
   private int heartbeat;
   private int maxFrameSize;
 
+  public ProtonServerOptions() {
+  }
+
+  public ProtonServerOptions(ProtonServerOptions other) {
+    super(other);
+    this.heartbeat = other.heartbeat;
+    this.maxFrameSize = other.maxFrameSize;
+  }
+
   @Override
   public ProtonServerOptions setSendBufferSize(int sendBufferSize) {
     super.setSendBufferSize(sendBufferSize);


### PR DESCRIPTION
This change adds copy constructors based on the already existing
super copy constructors.

Having a copy constructor helps creating immutable builders.

Signed-off-by: Jens Reimann <jreimann@redhat.com>