### PR TITLE
Fix #69

### DIFF
--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -30,7 +30,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.net.NetSocket;
 import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.sasl.ProtonSaslMechanism;
-import io.vertx.proton.sasl.SystemException;
+import io.vertx.proton.sasl.SaslSystemException;
 import io.vertx.proton.sasl.impl.ProtonSaslMechanismFinderImpl;
 
 /**
@@ -138,7 +138,7 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
           sasl.send(response, 0, response.length);
         }
       } else {
-        throw new SystemException(
+        throw new SaslSystemException(
             true, "Could not find a suitable SASL mechanism for the remote peer using the available credentials.");
       }
     }
@@ -159,9 +159,9 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
       throw new AuthenticationException("Failed to authenticate");
     case PN_SASL_SYS:
     case PN_SASL_TEMP:
-      throw new SystemException(false, "SASL handshake failed due to a transient error");
+      throw new SaslSystemException(false, "SASL handshake failed due to a transient error");
     case PN_SASL_PERM:
-      throw new SystemException(true, "SASL handshake failed due to an unrecoverable error");
+      throw new SaslSystemException(true, "SASL handshake failed due to an unrecoverable error");
     default:
       throw new SaslException("SASL handshake failed");
     }

--- a/src/main/java/io/vertx/proton/sasl/SaslSystemException.java
+++ b/src/main/java/io/vertx/proton/sasl/SaslSystemException.java
@@ -18,13 +18,15 @@ package io.vertx.proton.sasl;
 import javax.security.sasl.SaslException;
 
 /**
- * Indicates that a SASL handshake has failed with a {@code SYS}
- * response code as defined by <a href="https://tools.ietf.org/html/rfc3206#section-4">RFC 3206, Section 4</a>.
+ * Indicates that a SASL handshake has failed with a {@code sys-perm} or {@code sys-temp}
+ * response code as defined by
+ * <a href="http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-security-v1.0-os.html#type-sasl-code">
+ * AMQP Version 1.0, Section 5.3.3.6</a>.
  */
-public class SystemException extends SaslException {
+public class SaslSystemException extends SaslException {
 
   private static final long serialVersionUID = 1L;
-  private boolean permanent;
+  private final boolean permanent;
 
   /**
    * Creates an exception indicating a system error.
@@ -33,7 +35,7 @@ public class SystemException extends SaslException {
    *                  (manual) intervention.
    * 
    */
-  public SystemException(boolean permanent) {
+  public SaslSystemException(boolean permanent) {
     this(permanent, null);
   }
 
@@ -45,7 +47,7 @@ public class SystemException extends SaslException {
    * @param detail A message providing details about the cause
    *               of the problem.
    */
-  public SystemException(boolean permanent, String detail) {
+  public SaslSystemException(boolean permanent, String detail) {
     super(detail);
     this.permanent = permanent;
   }

--- a/src/main/java/io/vertx/proton/sasl/SystemException.java
+++ b/src/main/java/io/vertx/proton/sasl/SystemException.java
@@ -1,0 +1,61 @@
+/*
+* Copyright 2018 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton.sasl;
+
+import javax.security.sasl.SaslException;
+
+/**
+ * Indicates that a SASL handshake has failed with a {@code SYS}
+ * response code as defined by <a href="https://tools.ietf.org/html/rfc3206#section-4">RFC 3206, Section 4</a>.
+ */
+public class SystemException extends SaslException {
+
+  private static final long serialVersionUID = 1L;
+  private boolean permanent;
+
+  /**
+   * Creates an exception indicating a system error.
+   * 
+   * @param permanent {@code true} if the error is permanent and requires
+   *                  (manual) intervention.
+   * 
+   */
+  public SystemException(boolean permanent) {
+    this(permanent, null);
+  }
+
+  /**
+   * Creates an exception indicating a system error with a detail message.
+   * 
+   * @param permanent {@code true} if the error is permanent and requires
+   *                  (manual) intervention.
+   * @param detail A message providing details about the cause
+   *               of the problem.
+   */
+  public SystemException(boolean permanent, String detail) {
+    super(detail);
+    this.permanent = permanent;
+  }
+
+  /**
+   * Checks if the condition that caused this exception is of a permanent nature.
+   * 
+   * @return {@code true} if the error condition is permanent.
+   */
+  public final boolean isPermanent() {
+    return permanent;
+  }
+}

--- a/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
@@ -15,6 +15,8 @@
 */
 package io.vertx.proton;
 
+import javax.security.sasl.AuthenticationException;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +28,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.sasl.SystemException;
 import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 
 @RunWith(VertxUnitRunner.class)
@@ -63,20 +66,20 @@ public class ProtonClientSaslTest extends ActiveMQTestBase {
 
   @Test(timeout = 20000)
   public void testConnectWithValidUserPassSucceeds(TestContext context) throws Exception {
-    doConnectWithGivenCredentialsTestImpl(context, USERNAME_GUEST, PASSWORD_GUEST, true);
+    doConnectWithGivenCredentialsTestImpl(context, USERNAME_GUEST, PASSWORD_GUEST, null);
   }
 
   @Test(timeout = 20000)
   public void testConnectWithInvalidUserPassFails(TestContext context) throws Exception {
-    doConnectWithGivenCredentialsTestImpl(context, USERNAME_GUEST, "wrongpassword", false);
+    doConnectWithGivenCredentialsTestImpl(context, USERNAME_GUEST, "wrongpassword", AuthenticationException.class);
   }
 
   @Test(timeout = 20000)
   public void testConnectAnonymousWithoutUserPass(TestContext context) throws Exception {
-    doConnectWithGivenCredentialsTestImpl(context, null, null, false);
+    doConnectWithGivenCredentialsTestImpl(context, null, null, AuthenticationException.class);
     anonymousAccessAllowed = true;
     restartBroker();
-    doConnectWithGivenCredentialsTestImpl(context, null, null, true);
+    doConnectWithGivenCredentialsTestImpl(context, null, null, null);
   }
 
   @Test(timeout = 20000)
@@ -84,33 +87,40 @@ public class ProtonClientSaslTest extends ActiveMQTestBase {
     ProtonClientOptions options = new ProtonClientOptions();
 
     // Try with the wrong password, with anonymous access disabled, expect connect to fail
-    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", false);
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", AuthenticationException.class);
 
     // Try with the wrong password, with anonymous access enabled, expect connect still to fail
     anonymousAccessAllowed = true;
     restartBroker();
-    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", false);
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", AuthenticationException.class);
 
     // Now restrict the allows SASL mechanisms to ANONYMOUS, then expect connect to succeed as it wont use the invalid
     // credentials
     options.addEnabledSaslMechanism(ProtonSaslAnonymousImpl.MECH_NAME);
-    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", true);
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", null);
+  }
+
+  @Test(timeout = 20000)
+  public void testConnectWithUnsupportedSaslMechanisms(TestContext context) throws Exception {
+    ProtonClientOptions options = new ProtonClientOptions();
+    options.addEnabledSaslMechanism("NON_EXISTING");
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", SystemException.class);
   }
 
   private void doConnectWithGivenCredentialsTestImpl(TestContext context, String username, String password,
-                                                     boolean expectConnectToSucceed) {
+                                                     Class<?> expectedException) {
     doConnectWithGivenCredentialsTestImpl(context, new ProtonClientOptions(), username, password,
-        expectConnectToSucceed);
+        expectedException);
   }
 
   private void doConnectWithGivenCredentialsTestImpl(TestContext context, ProtonClientOptions options, String username,
-                                                     String password, boolean expectConnectToSucceed) {
+                                                     String password, Class<?> expectedException) {
     Async async = context.async();
 
     // Connect the client and open the connection to verify it works
     ProtonClient client = ProtonClient.create(vertx);
     client.connect(options, "localhost", getBrokerAmqpConnectorPort(), username, password, res -> {
-      if (expectConnectToSucceed) {
+      if (expectedException == null) {
         // Expect connect to succeed
         context.assertTrue(res.succeeded());
         ProtonConnection connection = res.result();
@@ -123,7 +133,8 @@ public class ProtonClientSaslTest extends ActiveMQTestBase {
       } else {
         // Expect connect to fail
         context.assertFalse(res.succeeded());
-        LOG.trace("Connect failed");
+        context.assertTrue(expectedException.isInstance(res.cause()));
+        LOG.trace("Connect failed: " + res.cause().getMessage());
         async.complete();
       }
     });

--- a/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
@@ -28,7 +28,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.proton.sasl.SystemException;
+import io.vertx.proton.sasl.SaslSystemException;
 import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 
 @RunWith(VertxUnitRunner.class)
@@ -104,7 +104,7 @@ public class ProtonClientSaslTest extends ActiveMQTestBase {
   public void testConnectWithUnsupportedSaslMechanisms(TestContext context) throws Exception {
     ProtonClientOptions options = new ProtonClientOptions();
     options.addEnabledSaslMechanism("NON_EXISTING");
-    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", SystemException.class);
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", SaslSystemException.class);
   }
 
   private void doConnectWithGivenCredentialsTestImpl(TestContext context, String username, String password,


### PR DESCRIPTION
The SASL client now fails the result handler with a subclass of
javax.securtiy.sasl.SaslException to indicate the reason for the
failure.

I have changed the type of exception to be used for failing the result handler to Java's standard exception type for SASL. So far, the JavaDoc of `ProtonSaslClientAuthenticatorImpl`'s constructor does not specify the concrete type that the handler would be failed with, so I assume that existing clients should not rely on the fact that the handler had failed with a `java.lang.SecurityException` so far. My understanding of the JavaDoc for `SecurityException` is, that it is intended to be thrown by a security manager when refusing access to a type/field etc., so I think it was not really the correct exception to use in the first place.
