### PR TITLE
Use proton buffer wrappers to improve send performance

### DIFF
--- a/src/main/java/io/vertx/proton/impl/ProtonReadableBufferImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonReadableBufferImpl.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.proton.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.WritableBuffer;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Proton ReadableBuffer implementation that wraps a Netty ByteBuf
+ */
+public class ProtonReadableBufferImpl implements ReadableBuffer {
+
+  private ByteBuf buffer;
+
+  public ProtonReadableBufferImpl(ByteBuf buffer) {
+    this.buffer = buffer;
+  }
+
+  public ByteBuf getBuffer() {
+    return buffer;
+  }
+
+  @Override
+  public int capacity() {
+    return buffer.capacity();
+  }
+
+  @Override
+  public boolean hasArray() {
+    return buffer.hasArray();
+  }
+
+  @Override
+  public byte[] array() {
+    return buffer.array();
+  }
+
+  @Override
+  public int arrayOffset() {
+    return buffer.arrayOffset() + buffer.readerIndex();
+  }
+
+  @Override
+  public ReadableBuffer reclaimRead() {
+    return this;
+  }
+
+  @Override
+  public byte get() {
+    return buffer.readByte();
+  }
+
+  @Override
+  public byte get(int index) {
+    return buffer.getByte(index);
+  }
+
+  @Override
+  public int getInt() {
+    return buffer.readInt();
+  }
+
+  @Override
+  public long getLong() {
+    return buffer.readLong();
+  }
+
+  @Override
+  public short getShort() {
+    return buffer.readShort();
+  }
+
+  @Override
+  public float getFloat() {
+    return buffer.readFloat();
+  }
+
+  @Override
+  public double getDouble() {
+    return buffer.readDouble();
+  }
+
+  @Override
+  public ReadableBuffer get(byte[] target, int offset, int length) {
+    buffer.readBytes(target, offset, length);
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer get(byte[] target) {
+    buffer.readBytes(target);
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer get(WritableBuffer target) {
+    int start = target.position();
+
+    if (buffer.hasArray()) {
+      target.put(buffer.array(), buffer.arrayOffset() + buffer.readerIndex(), buffer.readableBytes());
+    } else {
+      target.put(buffer.nioBuffer());
+    }
+
+    int written = target.position() - start;
+
+    buffer.readerIndex(buffer.readerIndex() + written);
+
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer slice() {
+    return new ProtonReadableBufferImpl(buffer.slice());
+  }
+
+  @Override
+  public ReadableBuffer flip() {
+    buffer.setIndex(0, buffer.readerIndex());
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer limit(int limit) {
+    buffer.writerIndex(limit);
+    return this;
+  }
+
+  @Override
+  public int limit() {
+    return buffer.writerIndex();
+  }
+
+  @Override
+  public ReadableBuffer position(int position) {
+    buffer.readerIndex(position);
+    return this;
+  }
+
+  @Override
+  public int position() {
+    return buffer.readerIndex();
+  }
+
+  @Override
+  public ReadableBuffer mark() {
+    buffer.markReaderIndex();
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer reset() {
+    buffer.resetReaderIndex();
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer rewind() {
+    buffer.readerIndex(0);
+    return this;
+  }
+
+  @Override
+  public ReadableBuffer clear() {
+    buffer.setIndex(0, buffer.capacity());
+    return this;
+  }
+
+  @Override
+  public int remaining() {
+    return buffer.readableBytes();
+  }
+
+  @Override
+  public boolean hasRemaining() {
+    return buffer.isReadable();
+  }
+
+  @Override
+  public ReadableBuffer duplicate() {
+    return new ProtonReadableBufferImpl(buffer.duplicate());
+  }
+
+  @Override
+  public ByteBuffer byteBuffer() {
+    return buffer.nioBuffer();
+  }
+
+  @Override
+  public String readUTF8() throws CharacterCodingException {
+    return buffer.toString(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public String readString(CharsetDecoder decoder) throws CharacterCodingException {
+    return buffer.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/src/main/java/io/vertx/proton/impl/ProtonWritableBufferImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonWritableBufferImpl.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.proton.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.WritableBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Proton WritableBuffer implementation that wraps a Netty ByteBuf
+ */
+public class ProtonWritableBufferImpl implements WritableBuffer {
+
+  public static final int INITIAL_CAPACITY = 1024;
+
+  public ByteBuf nettyBuffer;
+
+  public ProtonWritableBufferImpl() {
+    this(INITIAL_CAPACITY);
+  }
+
+  public ProtonWritableBufferImpl(int initialCapacity) {
+    nettyBuffer = Unpooled.buffer(initialCapacity);
+  }
+
+  public ProtonWritableBufferImpl(ByteBuf buffer) {
+    nettyBuffer = buffer;
+  }
+
+  public ByteBuf getBuffer() {
+    return nettyBuffer;
+  }
+
+  @Override
+  public void put(byte b) {
+    nettyBuffer.writeByte(b);
+  }
+
+  @Override
+  public void putFloat(float f) {
+    nettyBuffer.writeFloat(f);
+  }
+
+  @Override
+  public void putDouble(double d) {
+    nettyBuffer.writeDouble(d);
+  }
+
+  @Override
+  public void put(byte[] src, int offset, int length) {
+    nettyBuffer.writeBytes(src, offset, length);
+  }
+
+  @Override
+  public void put(ByteBuffer payload) {
+    nettyBuffer.writeBytes(payload);
+  }
+
+  public void put(ByteBuf payload) {
+    nettyBuffer.writeBytes(payload);
+  }
+
+  @Override
+  public void putShort(short s) {
+    nettyBuffer.writeShort(s);
+  }
+
+  @Override
+  public void putInt(int i) {
+    nettyBuffer.writeInt(i);
+  }
+
+  @Override
+  public void putLong(long l) {
+    nettyBuffer.writeLong(l);
+  }
+
+  @Override
+  public boolean hasRemaining() {
+    return nettyBuffer.writerIndex() < nettyBuffer.maxCapacity();
+  }
+
+  @Override
+  public int remaining() {
+    return nettyBuffer.maxCapacity() - nettyBuffer.writerIndex();
+  }
+
+  @Override
+  public int position() {
+    return nettyBuffer.writerIndex();
+  }
+
+  @Override
+  public void position(int position) {
+    nettyBuffer.writerIndex(position);
+  }
+
+  @Override
+  public int limit() {
+    return nettyBuffer.capacity();
+  }
+
+  @Override
+  public void put(ReadableBuffer buffer) {
+    buffer.get(this);
+  }
+
+  @Override
+  public void put(String value) {
+    nettyBuffer.writeCharSequence(value, StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/io/vertx/proton/impl/ProtonReadableBufferImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonReadableBufferImplTest.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.proton.impl;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Tests for the ReadableBuffer wrapper that uses Netty ByteBuf underneath
+ */
+public class ProtonReadableBufferImplTest {
+
+  @Test
+  public void testWrapBuffer() {
+    ByteBuf byteBuffer = Unpooled.buffer(100, 100);
+
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(100, buffer.capacity());
+    assertSame(byteBuffer, buffer.getBuffer());
+    assertSame(buffer, buffer.reclaimRead());
+  }
+
+  @Test
+  public void testArrayAccess() {
+    ByteBuf byteBuffer = Unpooled.buffer(100, 100);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertTrue(buffer.hasArray());
+    assertSame(buffer.array(), byteBuffer.array());
+    assertEquals(buffer.arrayOffset(), byteBuffer.arrayOffset());
+  }
+
+  @Test
+  public void testArrayAccessWhenNoArray() {
+    ByteBuf byteBuffer = Unpooled.directBuffer();
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertFalse(buffer.hasArray());
+  }
+
+  @Test
+  public void testByteBuffer() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    ByteBuffer nioBuffer = buffer.byteBuffer();
+    assertEquals(data.length, nioBuffer.remaining());
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], nioBuffer.get());
+    }
+  }
+
+  @Test
+  public void testGet() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.get();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetIndex() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get(i));
+    }
+
+    assertTrue(buffer.hasRemaining());
+  }
+
+  @Test
+  public void testGetShort() {
+    byte[] data = new byte[] { 0, 1 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(1, buffer.getShort());
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.getShort();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetInt() {
+    byte[] data = new byte[] { 0, 0, 0, 1 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(1, buffer.getInt());
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.getInt();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetLong() {
+    byte[] data = new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(1, buffer.getLong());
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.getLong();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetFloat() {
+    byte[] data = new byte[] { 0, 0, 0, 0 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(0, buffer.getFloat(), 0.0);
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.getFloat();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetDouble() {
+    byte[] data = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(0, buffer.getDouble(), 0.0);
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.getDouble();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetBytes() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    byte[] target = new byte[data.length];
+
+    buffer.get(target);
+    assertFalse(buffer.hasRemaining());
+    assertArrayEquals(data, target);
+
+    try {
+      buffer.get(target);
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetBytesIntInt() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    byte[] target = new byte[data.length];
+
+    buffer.get(target, 0, target.length);
+    assertFalse(buffer.hasRemaining());
+    assertArrayEquals(data, target);
+
+    try {
+      buffer.get(target, 0, target.length);
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testGetBytesToWritableBuffer() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+    ByteBuf targetBuffer = Unpooled.buffer(data.length, data.length);
+    ProtonWritableBufferImpl target = new ProtonWritableBufferImpl(targetBuffer);
+
+    buffer.get(target);
+    assertFalse(buffer.hasRemaining());
+    assertArrayEquals(targetBuffer.array(), data);
+  }
+
+  @Test
+  public void testGetBytesToWritableBufferThatIsDirect() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.directBuffer(data.length, data.length);
+    byteBuffer.writeBytes(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+    ByteBuf targetBuffer = Unpooled.buffer(data.length, data.length);
+    ProtonWritableBufferImpl target = new ProtonWritableBufferImpl(targetBuffer);
+
+    buffer.get(target);
+    assertFalse(buffer.hasRemaining());
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], target.getBuffer().readByte());
+    }
+  }
+
+  @Test
+  public void testDuplicate() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    ReadableBuffer duplicate = buffer.duplicate();
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], duplicate.get());
+    }
+
+    assertFalse(duplicate.hasRemaining());
+  }
+
+  @Test
+  public void testSlice() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    ReadableBuffer slice = buffer.slice();
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], slice.get());
+    }
+
+    assertFalse(slice.hasRemaining());
+  }
+
+  @Test
+  public void testLimit() {
+    byte[] data = new byte[] { 1, 2 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(data.length, buffer.limit());
+    buffer.limit(1);
+    assertEquals(1, buffer.limit());
+    assertEquals(1, buffer.get());
+    assertFalse(buffer.hasRemaining());
+
+    try {
+      buffer.get();
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+  }
+
+  @Test
+  public void testClear() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    byte[] target = new byte[data.length];
+
+    buffer.get(target);
+    assertFalse(buffer.hasRemaining());
+    assertArrayEquals(data, target);
+
+    try {
+      buffer.get(target);
+      fail("Should throw an IndexOutOfBoundsException");
+    } catch (IndexOutOfBoundsException ioe) {
+    }
+
+    buffer.clear();
+    assertTrue(buffer.hasRemaining());
+    assertEquals(data.length, buffer.remaining());
+    buffer.get(target);
+    assertFalse(buffer.hasRemaining());
+    assertArrayEquals(data, target);
+  }
+
+  @Test
+  public void testRewind() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+
+    assertFalse(buffer.hasRemaining());
+    buffer.rewind();
+    assertTrue(buffer.hasRemaining());
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+  }
+
+  @Test
+  public void testReset() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    buffer.mark();
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+
+    assertFalse(buffer.hasRemaining());
+    buffer.reset();
+    assertTrue(buffer.hasRemaining());
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+  }
+
+  @Test
+  public void testGetPosition() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(buffer.position(), 0);
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(buffer.position(), i);
+      assertEquals(data[i], buffer.get());
+      assertEquals(buffer.position(), i + 1);
+    }
+  }
+
+  @Test
+  public void testSetPosition() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+
+    assertFalse(buffer.hasRemaining());
+    buffer.position(0);
+    assertTrue(buffer.hasRemaining());
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+  }
+
+  @Test
+  public void testFlip() {
+    byte[] data = new byte[] { 0, 1, 2, 3, 4 };
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    buffer.mark();
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+
+    assertFalse(buffer.hasRemaining());
+    buffer.flip();
+    assertTrue(buffer.hasRemaining());
+
+    for (int i = 0; i < data.length; i++) {
+      assertEquals(data[i], buffer.get());
+    }
+  }
+
+  @Test
+  public void testReadUTF8() throws CharacterCodingException {
+    String testString = "test-string-1";
+    byte[] asUtf8bytes = testString.getBytes(StandardCharsets.UTF_8);
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(asUtf8bytes);
+
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(testString, buffer.readUTF8());
+  }
+
+  @Test
+  public void testReadString() throws CharacterCodingException {
+    String testString = "test-string-1";
+    byte[] asUtf8bytes = testString.getBytes(StandardCharsets.UTF_8);
+    ByteBuf byteBuffer = Unpooled.wrappedBuffer(asUtf8bytes);
+
+    ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
+
+    assertEquals(testString, buffer.readString(StandardCharsets.UTF_8.newDecoder()));
+  }
+}

--- a/src/test/java/io/vertx/proton/impl/ProtonWritableBufferImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonWritableBufferImplTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.proton.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Tests for behavior of ProtonWritableBufferImpl
+ */
+public class ProtonWritableBufferImplTest {
+
+  @Test
+  public void testGetBuffer() {
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertSame(buffer, writable.getBuffer());
+  }
+
+  @Test
+  public void testLimit() {
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(buffer.capacity(), writable.limit());
+  }
+
+  @Test
+  public void testRemaining() {
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(buffer.maxCapacity(), writable.remaining());
+    writable.put((byte) 0);
+    assertEquals(buffer.maxCapacity() - 1, writable.remaining());
+  }
+
+  @Test
+  public void testHasRemaining() {
+    ByteBuf buffer = Unpooled.buffer(100, 100);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertTrue(writable.hasRemaining());
+    writable.put((byte) 0);
+    assertTrue(writable.hasRemaining());
+    buffer.writerIndex(buffer.maxCapacity());
+    assertFalse(writable.hasRemaining());
+  }
+
+  @Test
+  public void testGetPosition() {
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(0, writable.position());
+    writable.put((byte) 0);
+    assertEquals(1, writable.position());
+  }
+
+  @Test
+  public void testSetPosition() {
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(0, writable.position());
+    writable.position(1);
+    assertEquals(1, writable.position());
+  }
+
+  @Test
+  public void testPutByteBuffer() {
+    ByteBuffer input = ByteBuffer.allocate(1024);
+    input.put((byte) 1);
+    input.flip();
+
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(0, writable.position());
+    writable.put(input);
+    assertEquals(1, writable.position());
+  }
+
+  @Test
+  public void testPutByteBuf() {
+    ByteBuf input = Unpooled.buffer();
+    input.writeByte((byte) 1);
+
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(0, writable.position());
+    writable.put(input);
+    assertEquals(1, writable.position());
+  }
+
+  @Test
+  public void testPutString() {
+    String ascii = new String("ASCII");
+
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(0, writable.position());
+    writable.put(ascii);
+    assertEquals(ascii.length(), writable.position());
+
+    ByteBuf written = writable.getBuffer();
+    assertEquals(ascii, written.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testPutReadableBuffer() {
+    doPutReadableBufferTestImpl(true);
+    doPutReadableBufferTestImpl(false);
+  }
+
+  private void doPutReadableBufferTestImpl(boolean readOnly) {
+    ByteBuffer buf = ByteBuffer.allocate(1024);
+    buf.put((byte) 1);
+    buf.flip();
+    if (readOnly) {
+      buf = buf.asReadOnlyBuffer();
+    }
+
+    ReadableBuffer input = new ReadableBuffer.ByteBufferReader(buf);
+
+    if (readOnly) {
+      assertFalse("Expected buffer not to hasArray()", input.hasArray());
+    } else {
+      assertTrue("Expected buffer to hasArray()", input.hasArray());
+    }
+
+    ByteBuf buffer = Unpooled.buffer(1024);
+    ProtonWritableBufferImpl writable = new ProtonWritableBufferImpl(buffer);
+
+    assertEquals(0, writable.position());
+    writable.put(input);
+    assertEquals(1, writable.position());
+  }
+}


### PR DESCRIPTION
Improve the performance of sends by using an Unpooled ByteBuf instance that expands when the encoding exceeds the initial capacity avoiding the double encoding that occurs using the 'encode2' method which will perform a full encode of the message and if the resulting encoding is larger than the 1024 byte initial buffer a second real encode is done to write to a buffer of the correct size.  

This change also uses the new put(String) API in the proton-j WritableBuffer interface to utilize the netty buffer string encoder which is far faster than the default implementation used in the proton-j interface.  For messages with an AmqpValue(String) the performance gain be be double or triple the current speed based on the payload size due to the avoidance of double encoding and using a string encoder that is faster than the method used in proton-j.  