### PR TITLE
Make use of new proton-j APIs to improve client performance

### DIFF
--- a/src/main/java/io/vertx/proton/impl/ProtonTransport.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonTransport.java
@@ -36,6 +36,7 @@ import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.Event.Type;
 import org.apache.qpid.proton.engine.Transport;
+import org.apache.qpid.proton.engine.impl.TransportInternal;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
@@ -71,6 +72,7 @@ class ProtonTransport extends BaseHandler {
     transport.setOutboundFrameSizeLimit(maxFrameSize);
     transport.setEmitFlowEventOnSend(false); // TODO: make configurable
     transport.setIdleTimeout(2 * options.getHeartbeat());
+    ((TransportInternal) transport).setUseReadOnlyOutputBuffer(false);
     if (authenticator != null) {
       authenticator.init(this.socket, (ProtonConnection) this.connection.getContext(), transport);
     }

--- a/src/main/java/io/vertx/proton/impl/ProtonWritableBufferImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonWritableBufferImpl.java
@@ -104,6 +104,11 @@ public class ProtonWritableBufferImpl implements WritableBuffer {
   }
 
   @Override
+  public void ensureRemaining(int remaining) {
+    nettyBuffer.ensureWritable(remaining);
+  }
+
+  @Override
   public int position() {
     return nettyBuffer.writerIndex();
   }


### PR DESCRIPTION
Use the APIs available in new proton-j releases to improve overall
performance on send.  Allows buffers to be sized ahead of large writes
to avoid multiple resizes and exposes the outgoing buffer as a
non-readonly byte buffer to allow for direct array copy to netty.

This is related to issue #87 update to proton-j 0.30.0