### PR TITLE
[#95] Throw AuthenticationException to indicate mechanism mismatch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test-tmp
 *.class
 *.swp
 .vertx
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
 
   <artifactId>vertx-proton</artifactId>
-  <version>3.6.0-SNAPSHOT</version>
+  <version>3.6.0</version>
 
   <name>Vert.x Proton</name>
 
@@ -37,7 +37,7 @@
 
   <properties>
     <!-- Dependency versions -->
-    <stack.version>3.6.0-SNAPSHOT</stack.version>
+    <stack.version>3.6.0</stack.version>
     <proton.version>0.31.0</proton.version>
 
     <!-- Test dependency versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
 
   <artifactId>vertx-proton</artifactId>
-  <version>3.6.0</version>
+  <version>4.0.0-SNAPSHOT</version>
 
   <name>Vert.x Proton</name>
 
@@ -37,7 +37,7 @@
 
   <properties>
     <!-- Dependency versions -->
-    <stack.version>3.6.0</stack.version>
+    <stack.version>4.0.0-SNAPSHOT</stack.version>
     <proton.version>0.31.0</proton.version>
 
     <!-- Test dependency versions -->

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -71,7 +71,6 @@ Explicitly override the hostname to use for the TLS SNI server name.
 |[[trustAll]]`@trustAll`|`Boolean`|-
 |[[trustStoreOptions]]`@trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
 |[[useAlpn]]`@useAlpn`|`Boolean`|-
-|[[usePooledBuffers]]`@usePooledBuffers`|`Boolean`|-
 |[[virtualHost]]`@virtualHost`|`String`|+++
 Override the hostname value used in the connection AMQP Open frame and TLS SNI server name (if TLS is in use).
  By default, the hostname specified in link will be used for both, with SNI performed
@@ -160,7 +159,6 @@ Sets the maximum frame size for connections.
 |[[trafficClass]]`@trafficClass`|`Number (int)`|-
 |[[trustStoreOptions]]`@trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
 |[[useAlpn]]`@useAlpn`|`Boolean`|-
-|[[usePooledBuffers]]`@usePooledBuffers`|`Boolean`|-
 |===
 
 [[ProtonTransportOptions]]

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -116,7 +116,6 @@ Sets whether the link remote terminus to be used should indicate it is
 ^|Name | Type ^| Description
 |[[acceptBacklog]]`@acceptBacklog`|`Number (int)`|-
 |[[clientAuth]]`@clientAuth`|`link:enums.html#ClientAuth[ClientAuth]`|-
-|[[clientAuthRequired]]`@clientAuthRequired`|`Boolean`|-
 |[[crlPaths]]`@crlPaths`|`Array of String`|-
 |[[crlValues]]`@crlValues`|`Array of Buffer`|-
 |[[enabledCipherSuites]]`@enabledCipherSuites`|`Array of String`|-

--- a/src/main/java/io/vertx/proton/ProtonClientOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonClientOptions.java
@@ -154,12 +154,6 @@ public class ProtonClientOptions extends NetClientOptions {
   }
 
   @Override
-  public ProtonClientOptions setUsePooledBuffers(boolean usePooledBuffers) {
-    super.setUsePooledBuffers(usePooledBuffers);
-    return this;
-  }
-
-  @Override
   public ProtonClientOptions setIdleTimeout(int idleTimeout) {
     super.setIdleTimeout(idleTimeout);
     return this;

--- a/src/main/java/io/vertx/proton/ProtonServerOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonServerOptions.java
@@ -204,13 +204,6 @@ public class ProtonServerOptions extends NetServerOptions {
   }
 
   @Override
-  @Deprecated
-  public ProtonServerOptions setClientAuthRequired(boolean clientAuthRequired) {
-    super.setClientAuthRequired(clientAuthRequired);
-    return this;
-  }
-
-  @Override
   public ProtonServerOptions setClientAuth(ClientAuth clientAuth) {
     super.setClientAuth(clientAuth);
     return this;

--- a/src/main/java/io/vertx/proton/ProtonServerOptions.java
+++ b/src/main/java/io/vertx/proton/ProtonServerOptions.java
@@ -120,12 +120,6 @@ public class ProtonServerOptions extends NetServerOptions {
   }
 
   @Override
-  public ProtonServerOptions setUsePooledBuffers(boolean usePooledBuffers) {
-    super.setUsePooledBuffers(usePooledBuffers);
-    return this;
-  }
-
-  @Override
   public ProtonServerOptions setIdleTimeout(int idleTimeout) {
     super.setIdleTimeout(idleTimeout);
     return this;

--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import javax.security.sasl.AuthenticationException;
 import javax.security.sasl.SaslException;
 
+import io.vertx.proton.sasl.MechanismMismatchException;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Transport;
@@ -138,8 +139,9 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
           sasl.send(response, 0, response.length);
         }
       } else {
-        throw new SaslSystemException(
-            true, "Could not find a suitable SASL mechanism for the remote peer using the available credentials.");
+        throw new MechanismMismatchException(
+            "Could not find a suitable SASL mechanism for the remote peer using the available credentials.",
+            remoteMechanisms);
       }
     }
   }

--- a/src/main/java/io/vertx/proton/sasl/MechanismMismatchException.java
+++ b/src/main/java/io/vertx/proton/sasl/MechanismMismatchException.java
@@ -1,0 +1,60 @@
+/*
+* Copyright 2019 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton.sasl;
+
+import javax.security.sasl.SaslException;
+
+/**
+ * Indicates that a SASL handshake has failed because the client does not support any of
+ * the mechanisms offered by the server.
+ */
+public class MechanismMismatchException extends SaslException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String[] offeredMechanisms;
+
+  /**
+   * Creates an exception with a detail message.
+   * 
+   * @param detail A message providing details about the cause
+   *               of the problem.
+   */
+  public MechanismMismatchException(String detail) {
+    this(detail, new String[0]);
+  }
+
+  /**
+   * Creates an exception with a detail message for offered mechanisms.
+   * 
+   * @param detail A message providing details about the cause
+   *               of the problem.
+   * @param mechanisms The names of the SASL mechanisms offered by the server.
+   */
+  public MechanismMismatchException(String detail, String[] mechanisms) {
+    super(detail);
+    this.offeredMechanisms = mechanisms;
+  }
+
+  /**
+   * Gets the names of the SASL mechanisms offered by the server.
+   * 
+   * @return The mechanisms.
+   */
+  public String[] getOfferedMechanisms() {
+    return offeredMechanisms;
+  }
+}

--- a/src/test/java/io/vertx/proton/ProtonClientOptionsTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientOptionsTest.java
@@ -22,54 +22,6 @@ import org.junit.Test;
 public class ProtonClientOptionsTest {
 
   @Test
-  public void testEqualsItself() {
-    ProtonClientOptions options = new ProtonClientOptions();
-
-    assertEquals("Options should be equal to itself", options, options);
-  }
-
-  @Test
-  public void testDifferentObjectsEqual() {
-    ProtonClientOptions options1 = new ProtonClientOptions();
-    options1.addEnabledSaslMechanism("PLAIN");
-    ProtonClientOptions options2 = new ProtonClientOptions();
-    options2.addEnabledSaslMechanism("PLAIN");
-
-    assertNotSame("Options should be different objects", options1, options2);
-    assertEquals("Options should be equal", options1, options2);
-  }
-
-  @Test
-  public void testDifferentObjectsNotEqual() {
-    ProtonClientOptions options1 = new ProtonClientOptions();
-    options1.addEnabledSaslMechanism("PLAIN");
-    ProtonClientOptions options2 = new ProtonClientOptions();
-    options2.addEnabledSaslMechanism("ANONYMOUS");
-
-    assertNotSame("Options should be different objects", options1, options2);
-    assertNotEquals("Options should not be equal", options1, options2);
-  }
-
-  @Test
-  public void testEqualObjectsReturnSameHashCode() {
-    ProtonClientOptions options1 = new ProtonClientOptions();
-    options1.addEnabledSaslMechanism("PLAIN");
-    ProtonClientOptions options2 = new ProtonClientOptions();
-    options2.addEnabledSaslMechanism("PLAIN");
-
-    assertNotSame("Options should be different objects", options1, options2);
-    assertEquals("Options should be equal", options1, options2);
-    assertEquals("Options should have same hash code", options1.hashCode(), options2.hashCode());
-  }
-
-  @Test
-  public void testEqualsNull() {
-    ProtonClientOptions options = new ProtonClientOptions();
-
-    assertFalse("Options should not equal null", options.equals(null));
-  }
-
-  @Test
   public void testAddGetEnabledSaslMechanisms() {
     ProtonClientOptions options = new ProtonClientOptions();
 

--- a/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
@@ -28,6 +28,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.sasl.MechanismMismatchException;
 import io.vertx.proton.sasl.SaslSystemException;
 import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 
@@ -104,7 +105,7 @@ public class ProtonClientSaslTest extends ActiveMQTestBase {
   public void testConnectWithUnsupportedSaslMechanisms(TestContext context) throws Exception {
     ProtonClientOptions options = new ProtonClientOptions();
     options.addEnabledSaslMechanism("NON_EXISTING");
-    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", SaslSystemException.class);
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", MechanismMismatchException.class);
   }
 
   private void doConnectWithGivenCredentialsTestImpl(TestContext context, String username, String password,

--- a/src/test/java/io/vertx/proton/ProtonServerOptionsTest.java
+++ b/src/test/java/io/vertx/proton/ProtonServerOptionsTest.java
@@ -22,62 +22,6 @@ import static org.junit.Assert.*;
 public class ProtonServerOptionsTest {
 
   @Test
-  public void testEqualsItself() {
-    ProtonServerOptions options = new ProtonServerOptions();
-
-    assertEquals("Options should be equal to itself", options, options);
-  }
-
-  @Test
-  public void testDifferentObjectsEqual() {
-    ProtonServerOptions options1 = new ProtonServerOptions();
-    options1.setHeartbeat(1000);
-    ProtonServerOptions options2 = new ProtonServerOptions();
-    options2.setHeartbeat(1000);
-
-    assertNotSame("Options should be different objects", options1, options2);
-    assertEquals("Options should be equal", options1, options2);
-  }
-
-  @Test
-  public void testDifferentObjectsNotEqual() {
-    ProtonServerOptions options1 = new ProtonServerOptions();
-    options1.setHeartbeat(1000);
-    ProtonServerOptions options2 = new ProtonServerOptions();
-    options2.setHeartbeat(2000);
-
-    assertNotSame("Options should be different objects", options1, options2);
-    assertNotEquals("Options should not be equal", options1, options2);
-  }
-
-  @Test
-  public void testEqualObjectsReturnSameHashCode() {
-    ProtonServerOptions options1 = new ProtonServerOptions();
-    options1.setHeartbeat(1000);
-    ProtonServerOptions options2 = new ProtonServerOptions();
-    options2.setHeartbeat(1000);
-
-    assertNotSame("Options should be different objects", options1, options2);
-    assertEquals("Options should be equal", options1, options2);
-    assertEquals("Options should have same hash code", options1.hashCode(), options2.hashCode());
-  }
-
-  @Test
-  public void testEqualsNull() {
-    ProtonServerOptions options = new ProtonServerOptions();
-
-    assertFalse("Options should not equal null", options.equals(null));
-  }
-
-  @Test
-  public void testHashCodeReturnsSameValueOnRepeatedCall() {
-    ProtonServerOptions options = new ProtonServerOptions();
-    options.setHeartbeat(1000);
-
-    assertEquals("Options should have same hash code for both calls", options.hashCode(), options.hashCode());
-  }
-
-  @Test
   public void testHeartbeat() {
     ProtonServerOptions options = new ProtonServerOptions();
 


### PR DESCRIPTION
Use a subclass of `javax.security.sasl.AuthenticationException` to fail a handshake on the client side if the client does not support any of the mechanisms offered by the server.
