### PR TITLE
[#95] Throw specific SaslException to indicate mechanism mismatch.

### DIFF
--- a/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonSaslClientAuthenticatorImpl.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import javax.security.sasl.AuthenticationException;
 import javax.security.sasl.SaslException;
 
+import io.vertx.proton.sasl.MechanismMismatchException;
 import io.vertx.proton.sasl.ProtonSaslAuthenticator;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Transport;
@@ -138,8 +139,9 @@ public class ProtonSaslClientAuthenticatorImpl implements ProtonSaslAuthenticato
           sasl.send(response, 0, response.length);
         }
       } else {
-        throw new SaslSystemException(
-            true, "Could not find a suitable SASL mechanism for the remote peer using the available credentials.");
+        throw new MechanismMismatchException(
+            "Could not find a suitable SASL mechanism for the remote peer using the available credentials.",
+            remoteMechanisms);
       }
     }
   }

--- a/src/main/java/io/vertx/proton/sasl/MechanismMismatchException.java
+++ b/src/main/java/io/vertx/proton/sasl/MechanismMismatchException.java
@@ -1,0 +1,60 @@
+/*
+* Copyright 2019 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.vertx.proton.sasl;
+
+import javax.security.sasl.SaslException;
+
+/**
+ * Indicates that a SASL handshake has failed because the client does not support any of
+ * the mechanisms offered by the server.
+ */
+public class MechanismMismatchException extends SaslException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String[] offeredMechanisms;
+
+  /**
+   * Creates an exception with a detail message.
+   * 
+   * @param detail A message providing details about the cause
+   *               of the problem.
+   */
+  public MechanismMismatchException(String detail) {
+    this(detail, new String[0]);
+  }
+
+  /**
+   * Creates an exception with a detail message for offered mechanisms.
+   * 
+   * @param detail A message providing details about the cause
+   *               of the problem.
+   * @param mechanisms The names of the SASL mechanisms offered by the server.
+   */
+  public MechanismMismatchException(String detail, String[] mechanisms) {
+    super(detail);
+    this.offeredMechanisms = mechanisms;
+  }
+
+  /**
+   * Gets the names of the SASL mechanisms offered by the server.
+   * 
+   * @return The mechanisms.
+   */
+  public String[] getOfferedMechanisms() {
+    return offeredMechanisms;
+  }
+}

--- a/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
+++ b/src/test/java/io/vertx/proton/ProtonClientSaslTest.java
@@ -28,6 +28,7 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.proton.sasl.MechanismMismatchException;
 import io.vertx.proton.sasl.SaslSystemException;
 import io.vertx.proton.sasl.impl.ProtonSaslAnonymousImpl;
 
@@ -104,7 +105,7 @@ public class ProtonClientSaslTest extends ActiveMQTestBase {
   public void testConnectWithUnsupportedSaslMechanisms(TestContext context) throws Exception {
     ProtonClientOptions options = new ProtonClientOptions();
     options.addEnabledSaslMechanism("NON_EXISTING");
-    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", SaslSystemException.class);
+    doConnectWithGivenCredentialsTestImpl(context, options, USERNAME_GUEST, "wrongpassword", MechanismMismatchException.class);
   }
 
   private void doConnectWithGivenCredentialsTestImpl(TestContext context, String username, String password,


### PR DESCRIPTION
Signed-off-by: Kai Hudalla <kai.hudalla@bosch-si.com>