### PR TITLE
[#57] Enforce max-message-size on receiver side

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonReceiver.java
+++ b/src/main/java/io/vertx/proton/ProtonReceiver.java
@@ -45,8 +45,8 @@ public interface ProtonReceiver extends ProtonLink<ProtonReceiver> {
    * <p>
    * The AMQP 1.0 specification requires the link to be detached with error code
    * <em>amqp:link:message-size-exceeded</em> in such a situation. Thus, after the handler returns,
-   * a corresponding AMQP <em>detach</em> frame with <em>close=true</em> will be sent to the peer,
-   * if the handler has not already detached the link manually.
+   * a corresponding AMQP <em>detach</em> frame with <em>close=false</em> will be sent to the peer,
+   * if the handler has not already detached or closed the link manually.
    * Note that the resources held by the link still need to be released in the close/detach handler(s)
    * using the {@link #free()} method, if appropriate.
    *

--- a/src/main/java/io/vertx/proton/ProtonReceiver.java
+++ b/src/main/java/io/vertx/proton/ProtonReceiver.java
@@ -36,6 +36,27 @@ public interface ProtonReceiver extends ProtonLink<ProtonReceiver> {
   ProtonReceiver handler(ProtonMessageHandler handler);
 
   /**
+   * Sets the handler to notify about a message from the peer that exceeds this receiver's configured
+   * maximum message size.
+   * <p>
+   * The handler will be invoked as soon as a transfer frame from the peer has been received which
+   * causes the max-message-size to be exceeded. This means that the full message may not have been
+   * received by that time.
+   * <p>
+   * The AMQP 1.0 specification requires the link to be detached with error code
+   * <em>amqp:link:message-size-exceeded</em> in such a situation. Thus, after the handler returns,
+   * a corresponding AMQP <em>detach</em> frame with <em>close=true</em> will be sent to the peer,
+   * if the handler has not already detached the link manually.
+   * Note that the resources held by the link still need to be released in the close/detach handler(s)
+   * using the {@link #free()} method, if appropriate.
+   *
+   * @param handler
+   *          the handler to invoke
+   * @return the receiver
+   */
+  ProtonReceiver maxMessageSizeExceededHandler(Handler<ProtonReceiver> handler);
+
+  /**
    * Sets the number of message credits the receiver grants and replenishes automatically as messages are delivered.
    *
    * To manage credit manually, you can instead set prefetch to 0 before opening the consumer and then explicitly call

--- a/src/main/java/io/vertx/proton/impl/ProtonReceiverImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonReceiverImpl.java
@@ -268,7 +268,7 @@ public class ProtonReceiverImpl extends ProtonLinkImpl<ProtonReceiver> implement
     if (!getReceiver().detached() && isOpen()) {
       LOG.debug("closing link with error condition " + LinkError.MESSAGE_SIZE_EXCEEDED);
       setCondition(new ErrorCondition(LinkError.MESSAGE_SIZE_EXCEEDED, "max-message-size of " + getMaxMessageSize() + " bytes exceeded"));
-      close();
+      detach();
     }
   }
 

--- a/src/test/java/io/vertx/proton/impl/ProtonReceiverImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonReceiverImplTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 the original author or authors.
+* Copyright 2016, 2020 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,20 +19,44 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.UnsignedLong;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.LinkError;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Receiver;
 import org.apache.qpid.proton.engine.Record;
 import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.engine.Transport;
+import org.apache.qpid.proton.message.Message;
+import org.apache.qpid.proton.message.impl.MessageImpl;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.NetSocketInternal;
-import io.vertx.core.net.NetSocket;
+import io.vertx.proton.ProtonDelivery;
+import io.vertx.proton.ProtonHelper;
+import io.vertx.proton.ProtonMessageHandler;
 import io.vertx.proton.ProtonReceiver;
 import io.vertx.proton.ProtonTransportOptions;
 
@@ -140,5 +164,255 @@ public class ProtonReceiverImplTest {
       // Expected
       assertFalse("drain should not have been completed", drain1complete.get());
     }
+  }
+
+  /**
+   * Verifies that the receiver detaches the link with an
+   * amqp:link:message-size-exceeded error code when receiving a single-transfer message that
+   * exceeds the link's max-message-size.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSingleTransferExceedingMaxMessageSizeResultsInLinkBeingDetached() {
+
+    int maxFrameSize = 80;
+    long maxMessageSize = 50;
+    Transport transport = mock(Transport.class);
+    when(transport.getMaxFrameSize()).thenReturn(maxFrameSize);
+
+    Connection con = mock(Connection.class);
+    ProtonConnectionImpl conImpl = new ProtonConnectionImpl(mock(Vertx.class), "hostname", mock(ContextInternal.class));
+    when(con.getTransport()).thenReturn(transport);
+    when(con.getContext()).thenReturn(conImpl);
+
+    Session session = mock(Session.class);
+    ProtonSessionImpl sessionImpl = new ProtonSessionImpl(session);
+    when(session.getConnection()).thenReturn(con);
+    when(session.getContext()).thenReturn(sessionImpl);
+    when(session.getIncomingCapacity()).thenReturn(10_000);
+    when(session.getIncomingBytes()).thenReturn(10_000);
+
+    Receiver r = mock(Receiver.class);
+    when(r.getLocalState()).thenReturn(EndpointState.ACTIVE);
+    when(r.getSession()).thenReturn(session);
+    when(r.getMaxMessageSize()).thenReturn(new UnsignedLong(maxMessageSize));
+    ProtonReceiverImpl recImpl = new ProtonReceiverImpl(r);
+    when(r.getContext()).thenReturn(recImpl);
+
+    ProtonMessageHandler messageHandler = mock(ProtonMessageHandler.class);
+    ProtonReceiverImpl receiver = new ProtonReceiverImpl(r);
+    receiver.handler(messageHandler);
+
+    byte[] encodedMessage = createEncodedMessage(70);
+    assertTrue(encodedMessage.length <= maxFrameSize);
+    assertTrue(encodedMessage.length > maxMessageSize);
+
+    ReadableBuffer frame0 = ReadableBuffer.ByteBufferReader.wrap(encodedMessage);
+
+    Delivery delivery0 = mock(Delivery.class);
+    when(delivery0.getLink()).thenReturn(r);
+    when(delivery0.isPartial()).thenReturn(false);
+    when(delivery0.available()).thenReturn(encodedMessage.length);
+    when(delivery0.isSettled()).thenReturn(false);
+
+    when(r.current()).thenReturn(delivery0);
+    when(r.recv()).thenReturn(frame0);
+
+    // WHEN delivering the message in a single transfer frame
+    receiver.onDelivery();
+
+    // THEN the receiver is being closed
+    verify(r).close();
+    // and the message is not being delivered to the application layer
+    verify(messageHandler, never()).handle(any(ProtonDelivery.class), any(Message.class));
+  }
+
+  /**
+   * Verifies that the receiver detaches the link with an
+   * amqp:link:message-size-exceeded error code when receiving a multi-transfer message that
+   * exceeds the link's max-message-size.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testMultiTransferExceedingMaxMessageSizeResultsInLinkBeingDetached() {
+
+    int maxFrameSize = 50;
+    long maxMessageSize = 65;
+    Transport transport = mock(Transport.class);
+    when(transport.getMaxFrameSize()).thenReturn(maxFrameSize);
+
+    Connection con = mock(Connection.class);
+    ProtonConnectionImpl conImpl = new ProtonConnectionImpl(mock(Vertx.class), "hostname", mock(ContextInternal.class));
+    when(con.getTransport()).thenReturn(transport);
+    when(con.getContext()).thenReturn(conImpl);
+
+    Session session = mock(Session.class);
+    ProtonSessionImpl sessionImpl = new ProtonSessionImpl(session);
+    when(session.getConnection()).thenReturn(con);
+    when(session.getContext()).thenReturn(sessionImpl);
+    when(session.getIncomingCapacity()).thenReturn(10_000);
+    when(session.getIncomingBytes()).thenReturn(10_000);
+
+    Receiver r = mock(Receiver.class);
+    when(r.getLocalState()).thenReturn(EndpointState.ACTIVE);
+    when(r.getSession()).thenReturn(session);
+    when(r.getMaxMessageSize()).thenReturn(new UnsignedLong(maxMessageSize));
+    ProtonReceiverImpl recImpl = new ProtonReceiverImpl(r);
+    when(r.getContext()).thenReturn(recImpl);
+
+    ProtonMessageHandler messageHandler = mock(ProtonMessageHandler.class);
+    Handler<ProtonReceiver> maxMessageSizeExceededHandler = mock(Handler.class);
+    doAnswer(invocation -> {
+      ProtonReceiver receiver = invocation.getArgument(0);
+      receiver.detach();
+      when(r.detached()).thenReturn(true);
+      return null;
+    }).when(maxMessageSizeExceededHandler).handle(any(ProtonReceiver.class));
+
+    ProtonReceiverImpl receiver = new ProtonReceiverImpl(r);
+    receiver.handler(messageHandler);
+    receiver.maxMessageSizeExceededHandler(maxMessageSizeExceededHandler);
+
+    byte[] encodedMessage = createEncodedMessage(70);
+    assertTrue(encodedMessage.length > maxFrameSize);
+    assertTrue(encodedMessage.length <= 2 * maxMessageSize);
+    assertTrue(encodedMessage.length > maxMessageSize);
+
+    byte[] chunk0 = new byte[maxFrameSize];
+    System.arraycopy(encodedMessage, 0, chunk0, 0, chunk0.length);
+    ReadableBuffer frame0 = ReadableBuffer.ByteBufferReader.wrap(chunk0);
+
+    Delivery delivery0 = mock(Delivery.class);
+    when(delivery0.getLink()).thenReturn(r);
+    when(delivery0.isPartial()).thenReturn(true);
+    when(delivery0.available()).thenReturn(chunk0.length);
+    when(delivery0.isSettled()).thenReturn(false);
+
+    byte[] chunk1 = new byte[encodedMessage.length - maxFrameSize];
+    System.arraycopy(encodedMessage, maxFrameSize, chunk1, 0, chunk1.length);
+    ReadableBuffer frame1 = ReadableBuffer.ByteBufferReader.wrap(chunk1);
+
+    Delivery delivery1 = mock(Delivery.class);
+    when(delivery1.getLink()).thenReturn(r);
+    when(delivery1.isPartial()).thenReturn(false);
+    when(delivery1.available()).thenReturn(chunk1.length);
+    when(delivery1.isSettled()).thenReturn(false);
+
+    when(r.current()).thenReturn(delivery0, delivery1);
+    when(r.recv()).thenReturn(frame0, frame1);
+
+    // WHEN delivering the message in two consecutive transfer frames
+    receiver.onDelivery();
+    receiver.onDelivery();
+
+    // THEN the maxMessageSizeExceeded handler is being invoked
+    verify(maxMessageSizeExceededHandler).handle(receiver);
+    // and the receiver has been detached by the maxMessageSizeExceeded handler
+    verify(r).detach();
+    verify(r, never()).close();
+    // and the message is not being delivered to the application layer
+    verify(messageHandler, never()).handle(any(ProtonDelivery.class), any(Message.class));
+  }
+
+  /**
+   * Verifies that the receiver accepts a multi-transfer message that does
+   * not exceed the link's max-message-size and delivers it to the application layer.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testMultiTransferMessage() {
+
+    int maxFrameSize = 50;
+    long maxMessageSize = 80;
+    Transport transport = mock(Transport.class);
+    when(transport.getMaxFrameSize()).thenReturn(maxFrameSize);
+
+    Connection con = mock(Connection.class);
+    ProtonConnectionImpl conImpl = new ProtonConnectionImpl(mock(Vertx.class), "hostname", mock(ContextInternal.class));
+    when(con.getTransport()).thenReturn(transport);
+    when(con.getContext()).thenReturn(conImpl);
+
+    Session session = mock(Session.class);
+    ProtonSessionImpl sessionImpl = new ProtonSessionImpl(session);
+    when(session.getConnection()).thenReturn(con);
+    when(session.getContext()).thenReturn(sessionImpl);
+    when(session.getIncomingCapacity()).thenReturn(10_000);
+    when(session.getIncomingBytes()).thenReturn(10_000);
+
+    Receiver r = mock(Receiver.class);
+    when(r.getLocalState()).thenReturn(EndpointState.ACTIVE);
+    when(r.getSession()).thenReturn(session);
+    when(r.getMaxMessageSize()).thenReturn(new UnsignedLong(maxMessageSize));
+    ProtonReceiverImpl recImpl = new ProtonReceiverImpl(r);
+    when(r.getContext()).thenReturn(recImpl);
+
+    ProtonMessageHandler messageHandler = mock(ProtonMessageHandler.class);
+    Handler<ProtonReceiver> maxMessageSizeExceededHandler = mock(Handler.class);
+    ProtonReceiverImpl receiver = new ProtonReceiverImpl(r);
+    receiver.handler(messageHandler);
+    receiver.maxMessageSizeExceededHandler(maxMessageSizeExceededHandler);
+
+    byte[] encodedMessage = createEncodedMessage(80);
+    assertTrue(encodedMessage.length > maxFrameSize);
+    assertTrue(encodedMessage.length <= 2 * maxMessageSize);
+    assertTrue(encodedMessage.length <= maxMessageSize);
+
+    byte[] chunk0 = new byte[maxFrameSize];
+    System.arraycopy(encodedMessage, 0, chunk0, 0, chunk0.length);
+    ReadableBuffer frame0 = ReadableBuffer.ByteBufferReader.wrap(chunk0);
+
+    Delivery delivery0 = mock(Delivery.class);
+    when(delivery0.getLink()).thenReturn(r);
+    when(delivery0.isPartial()).thenReturn(true);
+    when(delivery0.available()).thenReturn(chunk0.length);
+    when(delivery0.isSettled()).thenReturn(false);
+
+    byte[] chunk1 = new byte[encodedMessage.length - maxFrameSize];
+    System.arraycopy(encodedMessage, maxFrameSize, chunk1, 0, chunk1.length);
+    ReadableBuffer frame1 = ReadableBuffer.ByteBufferReader.wrap(chunk1);
+
+    Delivery delivery1 = mock(Delivery.class);
+    when(delivery1.getLink()).thenReturn(r);
+    when(delivery1.isPartial()).thenReturn(false);
+    when(delivery1.available()).thenReturn(chunk1.length);
+    when(delivery1.isSettled()).thenReturn(false);
+
+    when(r.current()).thenReturn(delivery0, delivery1);
+    when(r.recv()).thenReturn(frame0, frame1);
+
+    // WHEN delivering the message in two consecutive transfer frames
+    receiver.onDelivery();
+    receiver.onDelivery();
+
+    // THEN the disposition in reply to the second transfer has state accepted
+    verify(delivery1).disposition(any(Accepted.class));
+    // and the receiver has been advanced to the next delivery
+    verify(r).advance();
+    // and the sender has been issued a new credit
+    verify(r).flow(1);
+    // and the message has been delivered to the application layer
+    verify(messageHandler).handle(any(ProtonDelivery.class), any(Message.class));
+    // and the link is not being closed
+    verify(r, never()).close();
+    verify(maxMessageSizeExceededHandler, never()).handle(any(ProtonReceiver.class));
+  }
+
+  private byte[] createEncodedMessage(int targetMessageSize) {
+
+    MessageImpl msg = (MessageImpl) ProtonHelper.message();
+    msg.setContentType("binary/opaque");
+    msg.setAddress("telemetry");
+
+    // the address and content-type etc incur an overhead of 48 bytes
+    byte[] payload = new byte[targetMessageSize - 48];
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (i % 256);
+    }
+
+    msg.setBody(new Data(new Binary(payload)));
+
+    byte[] encodedMessage = new byte[targetMessageSize];
+    msg.encode2(encodedMessage, 0, encodedMessage.length);
+    return encodedMessage;
   }
 }


### PR DESCRIPTION
Motivation:

Receiver links do not enforce the max-message-size being set by client code. Senders are therefore able to send messages of arbitrary size to a receiver, thus exceeding its resource limits which can be exploited for a very easy to conduct DoS attack.

This PR changes the current behavior as follows:

A receiver link now checks if the receiver side's max-message-size is
being exceeded by an incoming transfer frame's content. If so, the
transfer is being rejected, thus preventing senders from exceeding the
receiver's resource limits.
