### PR TITLE
New handler on ProtonConnection for the OPENED state

### DIFF
--- a/src/main/java/io/vertx/proton/ProtonConnection.java
+++ b/src/main/java/io/vertx/proton/ProtonConnection.java
@@ -271,6 +271,15 @@ public interface ProtonConnection {
   ProtonConnection openHandler(Handler<AsyncResult<ProtonConnection>> remoteOpenHandler);
 
   /**
+   * Sets a handler for when respective AMQP Open frames are received from and sent to the remote peer.
+   *
+   * @param openedHandler
+   *          the handler
+   * @return the connection
+   */
+  ProtonConnection openedHandler(Handler<AsyncResult<ProtonConnection>> openedHandler);
+
+  /**
    * Sets a handler for when an AMQP Close frame is received from the remote peer.
    *
    * @param remoteCloseHandler


### PR DESCRIPTION
Motivation:

During peer connection, if the server sends Open frame eagerly, without waiting on the client's Open frame, the openHandler on the client connection misses it and will never be called.
This change adds a "openedHandler" to the ProtonConnection which is fired only when an Open frame is received and an Open frame is sent.