### PR TITLE
[optimize] use zero array length

### DIFF
--- a/src/main/java/io/vertx/proton/streams/impl/ProtonPublisherImpl.java
+++ b/src/main/java/io/vertx/proton/streams/impl/ProtonPublisherImpl.java
@@ -93,7 +93,7 @@ public class ProtonPublisherImpl implements ProtonPublisher<Delivery> {
     }
 
     if(!capabilities.isEmpty()) {
-      Symbol[] caps = capabilities.toArray(new Symbol[capabilities.size()]);
+      Symbol[] caps = capabilities.toArray(new Symbol[0]);
       source.setCapabilities(caps);
     }
   }


### PR DESCRIPTION
Motivation:
`toArray` method only needs declare array, only need zero array length
