### PR TITLE
For making ProtonSaslExternalImpl RFC compliant

### DIFF
--- a/src/main/java/io/vertx/proton/sasl/impl/ProtonSaslExternalImpl.java
+++ b/src/main/java/io/vertx/proton/sasl/impl/ProtonSaslExternalImpl.java
@@ -23,7 +23,11 @@ public class ProtonSaslExternalImpl extends ProtonSaslMechanismImpl {
 
   @Override
   public byte[] getInitialResponse() {
-    return EMPTY;
+    String username = getUsername();
+    if(username == null || username.isEmpty()){
+      return EMPTY;
+    }
+    return username.getBytes(StandardCharsets.UTF_8);
   }
 
   @Override

--- a/src/main/java/io/vertx/proton/sasl/impl/ProtonSaslExternalImpl.java
+++ b/src/main/java/io/vertx/proton/sasl/impl/ProtonSaslExternalImpl.java
@@ -15,6 +15,7 @@
 */
 package io.vertx.proton.sasl.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 
 public class ProtonSaslExternalImpl extends ProtonSaslMechanismImpl {


### PR DESCRIPTION
Motivation:

[RFC](https://datatracker.ietf.org/doc/html/rfc4422#appendix-A.1)

SASL External mechanism is capable of transferring an authorization identity string. The client sends the initial response to the intial challenge by the server. It can be empty or non-empty.
Response is non-empty when the client is requesting to act as the identity represented by the (non-empty) string which is UTF-8 encoding of the requested authorization identity string. It is empty when the client is requesting to act as the identity the server associated with its authentication credentials.

We can notice that the initial response is configured in Line 26. It is always set to EMPTY (empty byte array defined here) and cannot be configured to a custom string that we can use as identity string. Hence this library is NOT RFC compliant

If we have to pass the authorization identity string to the server then we must configure the initial response of that client.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
