### PR TITLE
ReadableBuffer string reads must advance the read index

### DIFF
--- a/src/main/java/io/vertx/proton/impl/ProtonReadableBufferImpl.java
+++ b/src/main/java/io/vertx/proton/impl/ProtonReadableBufferImpl.java
@@ -208,11 +208,11 @@ public class ProtonReadableBufferImpl implements ReadableBuffer {
 
   @Override
   public String readUTF8() throws CharacterCodingException {
-    return buffer.toString(StandardCharsets.UTF_8);
+    return buffer.readCharSequence(buffer.readableBytes(), StandardCharsets.UTF_8).toString();
   }
 
   @Override
   public String readString(CharsetDecoder decoder) throws CharacterCodingException {
-    return buffer.toString(StandardCharsets.UTF_8);
+    return buffer.readCharSequence(buffer.readableBytes(), decoder.charset()).toString();
   }
 }

--- a/src/test/java/io/vertx/proton/impl/ProtonReadableBufferImplTest.java
+++ b/src/test/java/io/vertx/proton/impl/ProtonReadableBufferImplTest.java
@@ -438,6 +438,7 @@ public class ProtonReadableBufferImplTest {
     ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
 
     assertEquals(testString, buffer.readUTF8());
+    assertFalse(buffer.hasRemaining());
   }
 
   @Test
@@ -449,6 +450,7 @@ public class ProtonReadableBufferImplTest {
     ProtonReadableBufferImpl buffer = new ProtonReadableBufferImpl(byteBuffer);
 
     assertEquals(testString, buffer.readString(StandardCharsets.UTF_8.newDecoder()));
+    assertFalse(buffer.hasRemaining());
   }
 
   @Test


### PR DESCRIPTION
The contract of the ReadableBuffer from proton-j indicates that
the buffer implementations of the read string methods should
advance the read index. The current implementation is not doing
so but currently doesn't cause any issue because proton-j does
its string decoding with a slice, future versions might not do
this and the result would be failed decodes due to the index
not being advanced.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
